### PR TITLE
Add Steam media player entity

### DIFF
--- a/custom_components/pc_remote/__init__.py
+++ b/custom_components/pc_remote/__init__.py
@@ -14,6 +14,7 @@ from .coordinator import PcRemoteCoordinator
 _LOGGER = __import__("logging").getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
+    Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SWITCH,

--- a/custom_components/pc_remote/api.py
+++ b/custom_components/pc_remote/api.py
@@ -319,6 +319,86 @@ class PcRemoteClient:
             ) from err
 
     # ------------------------------------------------------------------
+    # Steam
+    # ------------------------------------------------------------------
+
+    async def get_steam_games(self) -> list[dict]:
+        """Get recently played Steam games."""
+        try:
+            async with self._session.get(
+                f"{self._base_url}/api/steam/games",
+                headers=self._headers,
+                timeout=_TIMEOUT,
+            ) as resp:
+                if resp.status == 401:
+                    raise InvalidAuthError("Invalid API key")
+                resp.raise_for_status()
+                result = await resp.json()
+                if not result.get("success", True):
+                    msg = result.get("message", "Unknown error")
+                    _LOGGER.warning("API call failed: %s", msg)
+                    raise CannotConnectError(f"API error: {msg}")
+                return result.get("data", result)
+        except (aiohttp.ClientConnectorError, aiohttp.ClientError, asyncio.TimeoutError) as err:
+            raise CannotConnectError(
+                f"Cannot connect to {self._base_url}"
+            ) from err
+
+    async def get_steam_running(self) -> dict | None:
+        """Get the currently running Steam game, or None."""
+        try:
+            async with self._session.get(
+                f"{self._base_url}/api/steam/running",
+                headers=self._headers,
+                timeout=_TIMEOUT,
+            ) as resp:
+                if resp.status == 401:
+                    raise InvalidAuthError("Invalid API key")
+                resp.raise_for_status()
+                result = await resp.json()
+                if not result.get("success", True):
+                    msg = result.get("message", "Unknown error")
+                    _LOGGER.warning("API call failed: %s", msg)
+                    raise CannotConnectError(f"API error: {msg}")
+                return result.get("data")  # Can be None if no game running
+        except (aiohttp.ClientConnectorError, aiohttp.ClientError, asyncio.TimeoutError) as err:
+            raise CannotConnectError(
+                f"Cannot connect to {self._base_url}"
+            ) from err
+
+    async def steam_run(self, app_id: int) -> None:
+        """Launch a Steam game (idempotent -- closes current if different)."""
+        try:
+            async with self._session.post(
+                f"{self._base_url}/api/steam/run/{app_id}",
+                headers=self._headers,
+                timeout=_TIMEOUT,
+            ) as resp:
+                if resp.status == 401:
+                    raise InvalidAuthError("Invalid API key")
+                resp.raise_for_status()
+        except (aiohttp.ClientConnectorError, aiohttp.ClientError, asyncio.TimeoutError) as err:
+            raise CannotConnectError(
+                f"Cannot connect to {self._base_url}"
+            ) from err
+
+    async def steam_stop(self) -> None:
+        """Stop the currently running Steam game."""
+        try:
+            async with self._session.post(
+                f"{self._base_url}/api/steam/stop",
+                headers=self._headers,
+                timeout=_TIMEOUT,
+            ) as resp:
+                if resp.status == 401:
+                    raise InvalidAuthError("Invalid API key")
+                resp.raise_for_status()
+        except (aiohttp.ClientConnectorError, aiohttp.ClientError, asyncio.TimeoutError) as err:
+            raise CannotConnectError(
+                f"Cannot connect to {self._base_url}"
+            ) from err
+
+    # ------------------------------------------------------------------
     # Connection test
     # ------------------------------------------------------------------
 

--- a/custom_components/pc_remote/coordinator.py
+++ b/custom_components/pc_remote/coordinator.py
@@ -34,6 +34,8 @@ class PcRemoteData:
     monitor_profiles: list[str] = field(default_factory=list)
     monitors: list[dict] = field(default_factory=list)
     apps: list[dict] = field(default_factory=list)
+    steam_games: list[dict] = field(default_factory=list)
+    steam_running: dict | None = None
 
 
 class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
@@ -117,5 +119,16 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
             data.apps = await self.client.get_apps()
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Failed to fetch apps: %s", err)
+
+        # Fetch Steam state
+        try:
+            data.steam_games = await self.client.get_steam_games()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Failed to fetch Steam games: %s", err)
+
+        try:
+            data.steam_running = await self.client.get_steam_running()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Failed to fetch Steam running game: %s", err)
 
         return data

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -1,0 +1,133 @@
+"""Media player platform for the PC Remote integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import PcRemoteClient
+from .const import DOMAIN, build_device_info
+from .coordinator import PcRemoteCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the media player platform."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: PcRemoteCoordinator = data["coordinator"]
+    client: PcRemoteClient = data["client"]
+    async_add_entities([PcRemoteSteamPlayer(coordinator, client, entry)])
+
+
+class PcRemoteSteamPlayer(
+    CoordinatorEntity[PcRemoteCoordinator], MediaPlayerEntity
+):
+    """Media player entity for Steam game control."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "steam"
+    _attr_icon = "mdi:steam"
+    _attr_supported_features = (
+        MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.STOP
+    )
+
+    def __init__(
+        self,
+        coordinator: PcRemoteCoordinator,
+        client: PcRemoteClient,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the media player entity."""
+        super().__init__(coordinator)
+        self._client = client
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_steam"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info from latest coordinator data."""
+        return build_device_info(
+            self._entry,
+            machine_name=self.coordinator.data.machine_name,
+            sw_version=self.coordinator.data.service_version,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Available only when the PC is online."""
+        return super().available and self.coordinator.data.online
+
+    @property
+    def state(self) -> MediaPlayerState:
+        """Return the state of the media player."""
+        if not self.coordinator.data.online:
+            return MediaPlayerState.OFF
+        if self.coordinator.data.steam_running:
+            return MediaPlayerState.PLAYING
+        return MediaPlayerState.IDLE
+
+    @property
+    def media_title(self) -> str | None:
+        """Return the title of the currently playing game."""
+        running = self.coordinator.data.steam_running
+        return running.get("name") if running else None
+
+    @property
+    def source(self) -> str | None:
+        """Return the current game as the source."""
+        running = self.coordinator.data.steam_running
+        return running.get("name") if running else None
+
+    @property
+    def source_list(self) -> list[str]:
+        """Return the list of recently played games."""
+        return [g.get("name", "") for g in self.coordinator.data.steam_games]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra state attributes."""
+        running = self.coordinator.data.steam_running
+        if running:
+            return {"app_id": running.get("appId")}
+        return None
+
+    async def async_select_source(self, source: str) -> None:
+        """Launch the selected game."""
+        # Find the appId for the selected game name
+        for game in self.coordinator.data.steam_games:
+            if game.get("name") == source:
+                app_id = game.get("appId")
+                if app_id is not None:
+                    await self._client.steam_run(app_id)
+                    # Optimistic update
+                    self.coordinator.data.steam_running = {
+                        "appId": app_id,
+                        "name": source,
+                    }
+                    self.async_write_ha_state()
+                return
+        _LOGGER.warning("Steam game not found in list: %s", source)
+
+    async def async_media_stop(self) -> None:
+        """Stop the currently running game."""
+        await self._client.steam_stop()
+        # Optimistic update
+        self.coordinator.data.steam_running = None
+        self.async_write_ha_state()

--- a/custom_components/pc_remote/strings.json
+++ b/custom_components/pc_remote/strings.json
@@ -1,5 +1,8 @@
 {
   "entity": {
+    "media_player": {
+      "steam": { "name": "Steam" }
+    },
     "select": {
       "audio_output": { "name": "Audio Output" },
       "monitor_profile": { "name": "Monitor Profile" },


### PR DESCRIPTION
## Summary
- New `media_player` entity for Steam game control
- Source list: top 20 recently played games
- State: playing (game running), idle (Steam running), off (PC offline)
- Select source to launch a game, stop to close the current game
- Optimistic state updates for immediate UI feedback
- Graceful degradation if Steam endpoints unavailable

## New/Modified Files
- `media_player.py` — new MediaPlayerEntity
- `api.py` — 4 new Steam client methods
- `coordinator.py` — steam_games + steam_running data fields
- `__init__.py` — MEDIA_PLAYER platform registration
- `strings.json` — Steam translation

## Test plan
- [ ] Verify media player card shows in HA dashboard
- [ ] Test source selection launches correct game
- [ ] Test stop button closes running game
- [ ] Verify state transitions (off → idle → playing)
- [ ] CI passes