### PR TITLE
feat: wake-and-play for Steam media player (v0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,14 @@ App switches are created dynamically based on apps configured in the Windows ser
 
 ## Roadmap
 
-### Wake-and-play
+### Wake-and-play (implemented in v0.9.0)
 
-The Steam media player caches the game list locally, so the source list remains populated even when the PC is off and across HA restarts. The next step is full wake-and-play: selecting a game while the PC is off will automatically wake and launch it.
+The Steam media player caches the game list locally, so the source list remains populated even when the PC is off and across HA restarts. Selecting a game while the PC is off automatically wakes and launches it.
 
-Planned steps:
-
-- [ ] When a game is selected and `online = false`, send a WoL magic packet
-- [ ] Poll `/api/health` until the service responds (PC is up)
-- [ ] Poll `/api/steam/running` until Steam is reachable (Steam may take longer to start than the service)
-- [ ] Launch the game via `/api/steam/run/{appId}`
+- [x] When a game is selected and `online = false`, send a WoL magic packet
+- [x] Poll `/api/health` until the service responds (PC is up)
+- [x] Poll `/api/steam/running` until Steam is reachable (Steam may take longer to start than the service)
+- [x] Launch the game via `/api/steam/run/{appId}`
 
 ## Known Issues
 
@@ -97,7 +95,7 @@ Fix options (service-side):
 
 `GET /api/monitor/profiles` returns an empty list if the `ProfilesPath` directory does not exist next to the service exe. The entity has no options to select.
 
-Fix: create the `monitor-profiles/` directory next to `HaPcRemote.Service.exe` and add `.cfg` files exported from MultiMonitorTool.
+Fix: add `.cfg` files exported from MultiMonitorTool to the `monitor-profiles/` directory next to `HaPcRemote.Service.exe` (created automatically on first run).
 
 ## License
 

--- a/custom_components/pc_remote/manifest.json
+++ b/custom_components/pc_remote/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/NeskireDK/ha-pc-remote/issues",
   "requirements": ["wakeonlan==3.1.0"],
-  "version": "0.8.0",
+  "version": "0.9.0",
   "zeroconf": [{"type": "_pc-remote._tcp.local."}]
 }

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -15,9 +16,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from wakeonlan import send_magic_packet
 
-from .api import PcRemoteClient
-from .const import DOMAIN, build_device_info
+from .api import CannotConnectError, PcRemoteClient
+from .const import CONF_MAC_ADDRESS, DOMAIN, build_device_info
 from .coordinator import PcRemoteCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,6 +61,7 @@ class PcRemoteSteamPlayer(
         self._client = client
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_steam"
+        self._wake_target: dict | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -77,6 +80,8 @@ class PcRemoteSteamPlayer(
     @property
     def state(self) -> MediaPlayerState:
         """Return the state of the media player."""
+        if self._wake_target is not None:
+            return MediaPlayerState.BUFFERING
         if not self.coordinator.data.online:
             return MediaPlayerState.OFF
         if self.coordinator.data.steam_running:
@@ -86,14 +91,14 @@ class PcRemoteSteamPlayer(
     @property
     def media_title(self) -> str | None:
         """Return the title of the currently playing game."""
-        running = self.coordinator.data.steam_running
-        return running.get("name") if running else None
+        target = self._wake_target or self.coordinator.data.steam_running
+        return target.get("name") if target else None
 
     @property
     def source(self) -> str | None:
         """Return the current game as the source."""
-        running = self.coordinator.data.steam_running
-        return running.get("name") if running else None
+        target = self._wake_target or self.coordinator.data.steam_running
+        return target.get("name") if target else None
 
     @property
     def source_list(self) -> list[str]:
@@ -103,28 +108,24 @@ class PcRemoteSteamPlayer(
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return extra state attributes."""
-        running = self.coordinator.data.steam_running
-        if running:
-            return {"app_id": running.get("appId")}
-        return None
+        target = self._wake_target or self.coordinator.data.steam_running
+        return {"app_id": target.get("appId")} if target else None
 
     async def async_select_source(self, source: str) -> None:
         """Launch the selected game."""
-        if not self.coordinator.data.online:
-            _LOGGER.warning("PC is offline, cannot launch game: %s", source)
-            return
-        # Find the appId for the selected game name
         for game in self.coordinator.data.steam_games:
             if game.get("name") == source:
                 app_id = game.get("appId")
-                if app_id is not None:
-                    await self._client.steam_run(app_id)
-                    # Optimistic update
-                    self.coordinator.data.steam_running = {
-                        "appId": app_id,
-                        "name": source,
-                    }
+                if app_id is None:
+                    return
+                if not self.coordinator.data.online:
+                    self._wake_target = {"appId": app_id, "name": source}
                     self.async_write_ha_state()
+                    self.hass.async_create_task(self._wake_and_play(app_id, source))
+                    return
+                await self._client.steam_run(app_id)
+                self.coordinator.data.steam_running = {"appId": app_id, "name": source}
+                self.async_write_ha_state()
                 return
         _LOGGER.warning("Steam game not found in list: %s", source)
 
@@ -136,3 +137,56 @@ class PcRemoteSteamPlayer(
         # Optimistic update
         self.coordinator.data.steam_running = None
         self.async_write_ha_state()
+
+    async def _wake_and_play(self, app_id: int, source: str) -> None:
+        """Wake the PC via WoL, then launch the game when Steam is ready."""
+        mac = self._entry.data.get(CONF_MAC_ADDRESS)
+        if mac:
+            try:
+                await self.hass.async_add_executor_job(send_magic_packet, mac)
+            except (ValueError, OSError) as err:
+                _LOGGER.error("Failed to send WoL packet: %s", err)
+
+        # Poll /api/health until service responds (max 3 minutes, every 5s)
+        online = False
+        for _ in range(36):
+            await asyncio.sleep(5)
+            try:
+                await self._client.get_health()
+                online = True
+                break
+            except CannotConnectError:
+                continue
+
+        if not online:
+            _LOGGER.warning("Wake-and-play: PC did not come online within timeout")
+            self._wake_target = None
+            self.async_write_ha_state()
+            return
+
+        # Retry launch — Steam/tray may not be ready immediately after boot
+        # steam_run() returns 200 silently if tray is down, so we verify via steam_running
+        launched = False
+        for attempt in range(4):
+            if attempt > 0:
+                await asyncio.sleep(15)
+            try:
+                await self._client.steam_run(app_id)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Wake-and-play steam_run attempt %d: %s", attempt + 1, err)
+            await asyncio.sleep(10)
+            try:
+                running = await self._client.get_steam_running()
+                if running and running.get("appId") == app_id:
+                    launched = True
+                    break
+            except Exception:  # noqa: BLE001
+                pass
+
+        if not launched:
+            _LOGGER.warning("Wake-and-play: game did not launch after 4 attempts")
+
+        self._wake_target = None
+        if launched:
+            self.coordinator.data.steam_running = {"appId": app_id, "name": source}
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary

- When a Steam game is selected while PC is offline, send WoL magic packet, then enter BUFFERING state showing the target game name
- Poll `/api/health` every 5s for up to 3 minutes until service responds
- Retry `steam_run` up to 4 times (15s apart) with verification via `GET /api/steam/running` to confirm the game launched
- On timeout or launch failure, entity returns to OFF state with warning logged
- Version bump to 0.9.0

Also fixes README: monitor-profiles directory is auto-created by the service.

## Test plan

- [ ] Select a game while PC is off → entity shows BUFFERING + game name in source
- [ ] WoL packet is sent; PC boots; entity transitions to PLAYING once game is running
- [ ] If PC never comes up: entity returns to OFF after ~3 minutes
- [ ] Normal online launch still works (no regression)
- [ ] Monitor profiles Known Issue text is accurate