### PR TITLE
feat: v1.0.2 — persist selections + improved wake-and-play

### DIFF
--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -51,18 +51,18 @@ The old architecture had a Windows Service (SYSTEM session) and a WinForms tray 
 - [x] Update Inno Setup installer (no service registration, startup via all-users startup folder, config migration)
 - [x] Update README
 
-#### 0.9.5 — Linux foundation *(service repo)*
+#### 0.9.5 — Linux foundation *(service repo)* *(done)*
 
 Same binary, headless mode, systemd user service.
 
-- [ ] Wrap all WinForms/tray code behind `OperatingSystem.IsWindows()` / `[SupportedOSPlatform]`
-- [ ] Add Linux `IPowerService`: `systemctl suspend` or `loginctl suspend`
-- [ ] Add Linux `ISteamPlatform`: filesystem path (`~/.steam/steam/`), running game via `/proc` or VDF, launch via `xdg-open steam://run/<id>`
-- [ ] Add Linux audio stub (`pactl`-based `ICliRunner` calls) — partial is fine initially
-- [ ] Add headless entry point (Linux): plain Kestrel + mDNS, no tray icon, SIGTERM clean exit
-- [ ] Add systemd user service unit file to release artifacts
-- [ ] Add Linux build job to GitHub Actions CI
-- [ ] Document install steps for Arch / Ubuntu / SteamOS in README
+- [x] Wrap all WinForms/tray code behind `OperatingSystem.IsWindows()` / `[SupportedOSPlatform]`
+- [x] Add Linux `IPowerService`: `systemctl suspend` or `loginctl suspend`
+- [x] Add Linux `ISteamPlatform`: filesystem path (`~/.steam/steam/`), running game via VDF, launch via `xdg-open steam://run/<id>`
+- [x] Add Linux audio (`pactl`-based `LinuxAudioService`)
+- [x] Add headless entry point (Linux): plain Kestrel + mDNS, no tray icon, SIGTERM clean exit
+- [x] Add systemd user service unit file to release artifacts
+- [x] Add Linux build job to GitHub Actions CI
+- [x] Document install steps in README
 
 ### Key decisions made
 
@@ -133,8 +133,8 @@ still idle, then sleep the PC. Closes the power-saving loop without manual actio
 
 ### 5. User Idle Time Sensor
 
-`GetLastInputInfo` Win32 API (via tray IPC) → seconds since last keyboard/mouse input.
+`GetLastInputInfo` Win32 API → seconds since last keyboard/mouse input.
 Guards the sleep blueprint against sleeping a PC that someone is actively using at the desk.
 
-- [ ] Service: tray IPC `getIdleSeconds`, expose via `GET /api/system/idle` *(service)*
+- [ ] Service: expose via `GET /api/system/idle` *(service)*
 - [ ] Integration: `sensor` entity "Idle Time" (device class `duration`) *(integration)*

--- a/README.md
+++ b/README.md
@@ -2,21 +2,20 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 
-Home Assistant custom integration for controlling a Windows PC via [ha-pc-remote-service](https://github.com/NeskireDK/ha-pc-remote-service).
+Home Assistant custom integration for controlling a PC remotely via [ha-pc-remote-service](https://github.com/NeskireDK/ha-pc-remote-service). Supports Windows (tray app) and Linux (headless daemon).
 
 ## Requirements
 
-- [ha-pc-remote-service](https://github.com/NeskireDK/ha-pc-remote-service) running on the target Windows PC
-- Home Assistant 2024.1.0+
+- [ha-pc-remote-service](https://github.com/NeskireDK/ha-pc-remote-service) v1.0+ running on the target PC
+- Home Assistant 2024.6.0+
 
 ## Installation
 
 ### HACS (Recommended)
 
-1. Add this repository as a custom repository in HACS
-2. Install "PC Remote"
-3. Restart Home Assistant
-4. Go to Settings > Integrations > Add > PC Remote
+1. Open HACS → Integrations → Search "PC Remote"
+2. Install and restart Home Assistant
+3. Go to Settings > Integrations > Add > PC Remote
 
 ### Manual
 
@@ -26,8 +25,8 @@ Copy `custom_components/pc_remote/` to your Home Assistant `custom_components/` 
 
 Two ways to add the integration:
 
-- **Zeroconf** -- Auto-discovered on your network. Just confirm and enter the API key.
-- **Manual** -- Enter host, port, and API key from the Windows service.
+- **Zeroconf** — Auto-discovered on your network. Just confirm and enter the API key.
+- **Manual** — Enter host, port, and API key from the service config.
 
 ## Entities
 
@@ -35,6 +34,7 @@ Two ways to add the integration:
 |--------|------|-------------|
 | Online | Binary Sensor | PC connectivity status |
 | Sleep | Button | Put PC to sleep |
+| PC Mode | Select | Apply a named mode (audio + monitors + volume + app) |
 | Audio Output | Select | Switch default audio output device |
 | Volume | Number | Master volume (0-100) |
 | Monitor Profile | Select | Apply a saved `.cfg` monitor profile |
@@ -42,18 +42,22 @@ Two ways to add the integration:
 | Steam | Media Player | Launch Steam games; shows BUFFERING + wakes PC if offline |
 | {App Name} | Switch | Launch/kill configured apps |
 
-App switches are created dynamically based on apps configured in the Windows service.
+App switches are created dynamically based on apps configured in the service. PC Mode options come from the `Modes` config section.
+
+## Blueprints
+
+Two automation blueprints are included:
+
+- **Couch Gaming** — switches PC Mode, wakes the PC, and launches a Steam game in one action
+- **Post-Session Sleep** — when the Steam player goes idle, waits N minutes and sleeps the PC
 
 ## Roadmap
 
-### Wake-and-play (implemented in v0.9.0)
-
-The Steam media player caches the game list locally, so the source list remains populated even when the PC is off and across HA restarts. Selecting a game while the PC is off automatically wakes and launches it.
-
-- [x] When a game is selected and `online = false`, send a WoL magic packet
-- [x] Poll `/api/health` until the service responds (PC is up)
-- [x] Poll `/api/steam/running` until Steam is reachable (Steam may take longer to start than the service)
-- [x] Launch the game via `/api/steam/run/{appId}`
+- [x] Wake-and-play: WoL + poll + Steam launch when PC is off *(v0.9.0)*
+- [x] PC Mode select entity *(v1.0)*
+- [x] Aggregated state coordinator (single poll call) *(v1.0)*
+- [x] Couch Gaming + Post-Session Sleep blueprints *(v1.0)*
+- [ ] User Idle Time sensor *(v1.1)*
 
 ## License
 

--- a/custom_components/pc_remote/__init__.py
+++ b/custom_components/pc_remote/__init__.py
@@ -58,6 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = PcRemoteCoordinator(hass, client, entry.entry_id)
     await coordinator.async_load_steam_cache()
+    await coordinator.load_selections()
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/pc_remote/api.py
+++ b/custom_components/pc_remote/api.py
@@ -426,8 +426,8 @@ class PcRemoteClient:
                 f"Cannot connect to {self._base_url}"
             ) from err
 
-    async def steam_run(self, app_id: int) -> None:
-        """Launch a Steam game (idempotent -- closes current if different)."""
+    async def steam_run(self, app_id: int) -> dict | None:
+        """Launch a Steam game, return running game dict or None."""
         try:
             async with self._session.post(
                 f"{self._base_url}/api/steam/run/{app_id}",
@@ -437,6 +437,8 @@ class PcRemoteClient:
                 if resp.status == 401:
                     raise InvalidAuthError("Invalid API key")
                 resp.raise_for_status()
+                result = await resp.json()
+                return result.get("data")  # SteamRunningGame dict or None
         except (aiohttp.ClientConnectorError, aiohttp.ClientError, asyncio.TimeoutError) as err:
             raise CannotConnectError(
                 f"Cannot connect to {self._base_url}"

--- a/custom_components/pc_remote/coordinator.py
+++ b/custom_components/pc_remote/coordinator.py
@@ -24,6 +24,9 @@ POWER_HOLD_SECONDS = 60
 STEAM_GAMES_STORAGE_VERSION = 1
 
 
+SELECTIONS_STORAGE_VERSION = 1
+
+
 @dataclass
 class PcRemoteData:
     """Data returned by the coordinator."""
@@ -40,6 +43,8 @@ class PcRemoteData:
     steam_games: list[dict] = field(default_factory=list)
     steam_running: dict | None = None
     modes: list[str] = field(default_factory=list)
+    current_mode: str | None = None
+    current_monitor_profile: str | None = None
 
 
 class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
@@ -66,6 +71,12 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
             f"{DOMAIN}.{entry_id}.steam_games",
         )
         self._cached_steam_games: list[dict] = []
+        self._selections_store: Store = Store(
+            hass,
+            SELECTIONS_STORAGE_VERSION,
+            f"{DOMAIN}.{entry_id}.selections",
+        )
+        self._prev_audio_device: str | None = None
 
     async def async_load_steam_cache(self) -> None:
         """Load persisted Steam game list from storage. Call before first refresh."""
@@ -73,6 +84,21 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
         if isinstance(stored, list):
             self._cached_steam_games = stored
             _LOGGER.debug("Loaded %d Steam games from cache", len(stored))
+
+    async def load_selections(self) -> dict:
+        """Load persisted selections from storage."""
+        stored = await self._selections_store.async_load()
+        if isinstance(stored, dict):
+            _LOGGER.debug("Loaded selections from cache: %s", stored)
+            return stored
+        return {}
+
+    async def persist_selection(self, key: str, value: str | None) -> None:
+        """Persist a selection to storage."""
+        stored = await self._selections_store.async_load()
+        selections = stored if isinstance(stored, dict) else {}
+        selections[key] = value
+        await self._selections_store.async_save(selections)
 
     def set_power_state(self, online: bool) -> None:
         """Hold an assumed power state until the next poll cycle catches up."""
@@ -122,6 +148,7 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
                 await self._steam_games_store.async_save(self._cached_steam_games)
             if not data.steam_games:
                 data.steam_games = list(self._cached_steam_games)
+            await self._restore_selections(data)
             return data
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Aggregated state fetch failed, falling back to individual calls: %s", err)
@@ -175,7 +202,42 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Failed to fetch modes: %s", err)
 
+        await self._restore_selections(data)
         return data
+
+    async def _restore_selections(self, data: PcRemoteData) -> None:
+        """Restore persisted mode/profile, invalidating stale values."""
+        selections = await self.load_selections()
+        mode = selections.get("mode")
+        profile = selections.get("monitor_profile")
+
+        # Restore mode only if still in the available list
+        if mode and mode in data.modes:
+            data.current_mode = mode
+        else:
+            data.current_mode = None
+
+        # Restore profile only if still in the available list
+        if profile and profile in data.monitor_profiles:
+            data.current_monitor_profile = profile
+        else:
+            data.current_monitor_profile = None
+
+        # Audio change detection: if the audio device changed externally, clear mode
+        if (
+            data.current_mode
+            and self._prev_audio_device is not None
+            and data.current_audio_device != self._prev_audio_device
+        ):
+            _LOGGER.debug(
+                "Audio device changed from %s to %s, clearing persisted mode",
+                self._prev_audio_device,
+                data.current_audio_device,
+            )
+            data.current_mode = None
+            await self.persist_selection("mode", None)
+
+        self._prev_audio_device = data.current_audio_device
 
     def _populate_from_system_state(self, data: PcRemoteData, state: dict) -> None:
         """Populate PcRemoteData from an aggregated /api/system/state response."""

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -148,11 +148,14 @@ class PcRemoteSteamPlayer(
                     )
                     return
                 try:
-                    await self._client.steam_run(app_id)
+                    result = await self._client.steam_run(app_id)
                 except CannotConnectError as err:
                     _LOGGER.error("Failed to launch Steam game '%s': %s", source, err)
                     return
-                self.coordinator.data.steam_running = {"appId": app_id, "name": source}
+                if result:
+                    self.coordinator.data.steam_running = result
+                else:
+                    self.coordinator.data.steam_running = {"appId": app_id, "name": source}
                 self.async_write_ha_state()
                 return
         _LOGGER.warning("Steam game not found in list: %s", source)
@@ -196,29 +199,25 @@ class PcRemoteSteamPlayer(
             self.async_write_ha_state()
             return
 
-        # Retry launch — Steam/tray may not be ready immediately after boot.
-        # steam_run() returns 200 silently if tray is down, so verify via get_steam_running.
-        launched = False
-        for attempt in range(4):
-            if attempt > 0:
-                await asyncio.sleep(15)
-            try:
-                await self._client.steam_run(app_id)
-            except CannotConnectError as err:
-                _LOGGER.debug("Wake-and-play steam_run attempt %d: %s", attempt + 1, err)
-            await asyncio.sleep(10)
-            try:
-                running = await self._client.get_steam_running()
-                if running and running.get("appId") == app_id:
-                    launched = True
-                    break
-            except CannotConnectError:
-                pass
+        # Launch — service now polls internally and returns the running game
+        result = None
+        try:
+            result = await self._client.steam_run(app_id)
+        except CannotConnectError as err:
+            _LOGGER.debug("Wake-and-play steam_run attempt 1: %s", err)
 
-        if not launched:
-            _LOGGER.warning("Wake-and-play: game did not launch after 4 attempts")
+        # One retry after 15s if Steam wasn't ready right after boot
+        if result is None:
+            await asyncio.sleep(15)
+            try:
+                result = await self._client.steam_run(app_id)
+            except CannotConnectError as err:
+                _LOGGER.debug("Wake-and-play steam_run attempt 2: %s", err)
+
+        if result is None:
+            _LOGGER.warning("Wake-and-play: game did not launch after 2 attempts")
 
         self._wake_target = None
-        if launched:
-            self.coordinator.data.steam_running = {"appId": app_id, "name": source}
+        if result:
+            self.coordinator.data.steam_running = result
         await self.coordinator.async_request_refresh()

--- a/custom_components/pc_remote/select.py
+++ b/custom_components/pc_remote/select.py
@@ -125,13 +125,15 @@ class PcRemoteMonitorProfileSelect(
 
     @property
     def current_option(self) -> str | None:
-        """Return the current option (not tracked)."""
-        return None
+        """Return the persisted monitor profile selection."""
+        return self.coordinator.data.current_monitor_profile
 
     async def async_select_option(self, option: str) -> None:
         """Activate the selected monitor profile."""
         await self._client.set_monitor_profile(option)
-        await self.coordinator.async_request_refresh()
+        self.coordinator.data.current_monitor_profile = option
+        await self.coordinator.persist_selection("monitor_profile", option)
+        self.async_write_ha_state()
 
 
 class PcRemoteMonitorSoloSelect(
@@ -220,7 +222,6 @@ class PcRemoteModeSelect(
         self._client = client
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_pc_mode"
-        self._current_mode: str | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -243,11 +244,12 @@ class PcRemoteModeSelect(
 
     @property
     def current_option(self) -> str | None:
-        """Return the last-set mode."""
-        return self._current_mode
+        """Return the persisted mode selection."""
+        return self.coordinator.data.current_mode
 
     async def async_select_option(self, option: str) -> None:
         """Apply the selected PC mode."""
         await self._client.set_mode(option)
-        self._current_mode = option
+        self.coordinator.data.current_mode = option
+        await self.coordinator.persist_selection("mode", option)
         self.async_write_ha_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,8 @@ def make_coordinator_data(**kwargs) -> PcRemoteData:
         ],
         steam_running=None,
         modes=["Gaming", "Work", "TV"],
+        current_mode=None,
+        current_monitor_profile=None,
     )
     defaults.update(kwargs)
     return PcRemoteData(**defaults)
@@ -255,6 +257,7 @@ def make_mock_coordinator(data: PcRemoteData | None = None) -> MagicMock:
     coordinator.hass.async_add_executor_job = AsyncMock()
     coordinator.hass.async_create_task = MagicMock()
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.persist_selection = AsyncMock()
     coordinator.available = True
     return coordinator
 
@@ -290,7 +293,7 @@ def make_mock_client() -> MagicMock:
     client.kill_app = AsyncMock()
     client.get_steam_games = AsyncMock(return_value=[])
     client.get_steam_running = AsyncMock(return_value=None)
-    client.steam_run = AsyncMock()
+    client.steam_run = AsyncMock(return_value=None)
     client.steam_stop = AsyncMock()
     client.get_modes = AsyncMock(return_value=[])
     client.set_mode = AsyncMock()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -284,11 +284,21 @@ class TestSteam:
 
     @pytest.mark.asyncio
     async def test_steam_run_posts_app_id(self):
-        resp = _make_response(200, {})
+        game = {"appId": 1091500, "name": "Cyberpunk 2077"}
+        resp = _make_response(200, {"success": True, "data": game})
         session = _make_session(resp)
         client = _make_client(session)
-        await client.steam_run(1091500)
+        result = await client.steam_run(1091500)
         assert "/api/steam/run/1091500" in session.post.call_args[0][0]
+        assert result["appId"] == 1091500
+
+    @pytest.mark.asyncio
+    async def test_steam_run_returns_none_when_not_confirmed(self):
+        resp = _make_response(200, {"success": True, "data": None})
+        session = _make_session(resp)
+        client = _make_client(session)
+        result = await client.steam_run(1091500)
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_steam_stop_posts_to_stop(self):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -311,3 +311,167 @@ class TestPopulateFromSystemState:
         coord._populate_from_system_state(data, state)
 
         assert data.steam_running["appId"] == 570
+
+
+# ---------------------------------------------------------------------------
+# Selection persistence
+# ---------------------------------------------------------------------------
+
+class TestSelectionPersistence:
+    @pytest.mark.asyncio
+    async def test_load_selections_returns_dict_from_store(self):
+        coord = _make_coordinator()
+        coord._selections_store._data = {"mode": "Gaming", "monitor_profile": "TV"}
+        result = await coord.load_selections()
+        assert result == {"mode": "Gaming", "monitor_profile": "TV"}
+
+    @pytest.mark.asyncio
+    async def test_load_selections_returns_empty_dict_when_no_data(self):
+        coord = _make_coordinator()
+        result = await coord.load_selections()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_persist_selection_saves_to_store(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "Work")
+        stored = await coord._selections_store.async_load()
+        assert stored == {"mode": "Work"}
+
+    @pytest.mark.asyncio
+    async def test_persist_selection_merges_with_existing(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "Work")
+        await coord.persist_selection("monitor_profile", "Desktop")
+        stored = await coord._selections_store.async_load()
+        assert stored == {"mode": "Work", "monitor_profile": "Desktop"}
+
+    @pytest.mark.asyncio
+    async def test_persist_selection_can_clear_value(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "Work")
+        await coord.persist_selection("mode", None)
+        stored = await coord._selections_store.async_load()
+        assert stored["mode"] is None
+
+
+# ---------------------------------------------------------------------------
+# _restore_selections
+# ---------------------------------------------------------------------------
+
+class TestRestoreSelections:
+    @pytest.mark.asyncio
+    async def test_restores_mode_when_in_available_list(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "Gaming")
+        data = PcRemoteData(modes=["Gaming", "Work"])
+        await coord._restore_selections(data)
+        assert data.current_mode == "Gaming"
+
+    @pytest.mark.asyncio
+    async def test_clears_mode_when_not_in_available_list(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "Removed")
+        data = PcRemoteData(modes=["Gaming", "Work"])
+        await coord._restore_selections(data)
+        assert data.current_mode is None
+
+    @pytest.mark.asyncio
+    async def test_restores_monitor_profile_when_in_available_list(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("monitor_profile", "Desktop")
+        data = PcRemoteData(monitor_profiles=["Desktop", "Gaming"])
+        await coord._restore_selections(data)
+        assert data.current_monitor_profile == "Desktop"
+
+    @pytest.mark.asyncio
+    async def test_clears_monitor_profile_when_not_in_available_list(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("monitor_profile", "Removed")
+        data = PcRemoteData(monitor_profiles=["Desktop", "Gaming"])
+        await coord._restore_selections(data)
+        assert data.current_monitor_profile is None
+
+    @pytest.mark.asyncio
+    async def test_audio_change_clears_persisted_mode(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "TV")
+        coord._prev_audio_device = "Speakers"
+
+        data = PcRemoteData(
+            modes=["TV", "Gaming"],
+            current_audio_device="Headphones",
+        )
+        await coord._restore_selections(data)
+
+        assert data.current_mode is None
+        stored = await coord._selections_store.async_load()
+        assert stored["mode"] is None
+
+    @pytest.mark.asyncio
+    async def test_audio_unchanged_keeps_persisted_mode(self):
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "TV")
+        coord._prev_audio_device = "Speakers"
+
+        data = PcRemoteData(
+            modes=["TV", "Gaming"],
+            current_audio_device="Speakers",
+        )
+        await coord._restore_selections(data)
+
+        assert data.current_mode == "TV"
+
+    @pytest.mark.asyncio
+    async def test_first_poll_does_not_clear_mode(self):
+        """On first poll _prev_audio_device is None, should not clear mode."""
+        coord = _make_coordinator()
+        await coord.persist_selection("mode", "TV")
+
+        data = PcRemoteData(
+            modes=["TV", "Gaming"],
+            current_audio_device="Speakers",
+        )
+        await coord._restore_selections(data)
+
+        assert data.current_mode == "TV"
+        assert coord._prev_audio_device == "Speakers"
+
+    @pytest.mark.asyncio
+    async def test_system_state_path_restores_selections(self):
+        """Full _async_update_data via system state restores persisted mode."""
+        client = make_mock_client()
+        client.get_health.return_value = {"machineName": "PC", "version": "1.0"}
+        client.get_system_state.return_value = _full_system_state()
+
+        coord = _make_coordinator(client)
+        await coord.persist_selection("mode", "Gaming")
+        await coord.persist_selection("monitor_profile", "Desktop")
+
+        data = await coord._async_update_data()
+
+        assert data.current_mode == "Gaming"
+        assert data.current_monitor_profile == "Desktop"
+
+    @pytest.mark.asyncio
+    async def test_fallback_path_restores_selections(self):
+        """Full _async_update_data via fallback restores persisted mode."""
+        client = make_mock_client()
+        client.get_health.return_value = {"machineName": "PC", "version": "1.0"}
+        client.get_system_state.side_effect = Exception("no state")
+        client.get_audio_devices.return_value = []
+        client.get_monitor_profiles.return_value = ["Desktop", "Gaming"]
+        client.get_monitors.return_value = []
+        client.get_apps.return_value = []
+        client.get_steam_games.return_value = []
+        client.get_steam_running.return_value = None
+        client.get_modes.return_value = ["Gaming", "Work"]
+
+        coord = _make_coordinator(client)
+        await coord.persist_selection("mode", "Gaming")
+        await coord.persist_selection("monitor_profile", "Desktop")
+
+        data = await coord._async_update_data()
+
+        assert data.current_mode == "Gaming"
+        assert data.current_monitor_profile == "Desktop"

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -163,15 +163,30 @@ class TestExtraAttributes:
 
 class TestSelectSource:
     @pytest.mark.asyncio
-    async def test_launches_game_when_online(self):
+    async def test_launches_game_when_online_confirmed(self):
+        """steam_run returns confirmed game data -- used directly."""
         games = [{"appId": 570, "name": "Dota 2"}]
         data = make_coordinator_data(online=True, steam_games=games)
         player, coordinator, client = _make_player(data)
+        client.steam_run = AsyncMock(return_value={"appId": 570, "name": "Dota 2"})
 
         await player.async_select_source("Dota 2")
 
         client.steam_run.assert_awaited_once_with(570)
-        assert coordinator.data.steam_running["appId"] == 570
+        assert coordinator.data.steam_running == {"appId": 570, "name": "Dota 2"}
+
+    @pytest.mark.asyncio
+    async def test_launches_game_when_online_not_confirmed(self):
+        """steam_run returns None -- falls back to optimistic update."""
+        games = [{"appId": 570, "name": "Dota 2"}]
+        data = make_coordinator_data(online=True, steam_games=games)
+        player, coordinator, client = _make_player(data)
+        client.steam_run = AsyncMock(return_value=None)
+
+        await player.async_select_source("Dota 2")
+
+        client.steam_run.assert_awaited_once_with(570)
+        assert coordinator.data.steam_running == {"appId": 570, "name": "Dota 2"}
 
     @pytest.mark.asyncio
     async def test_game_not_found_in_list_does_nothing(self):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -113,10 +113,18 @@ class TestMonitorProfileSelect:
         entity, *_ = _make_entity(PcRemoteMonitorProfileSelect, data)
         assert entity.options == []
 
-    def test_current_option_always_none(self):
-        data = make_coordinator_data(monitor_profiles=["Desktop"])
+    def test_current_option_none_when_not_persisted(self):
+        data = make_coordinator_data(monitor_profiles=["Desktop"], current_monitor_profile=None)
         entity, *_ = _make_entity(PcRemoteMonitorProfileSelect, data)
         assert entity.current_option is None
+
+    def test_current_option_returns_persisted_profile(self):
+        data = make_coordinator_data(
+            monitor_profiles=["Desktop", "Gaming"],
+            current_monitor_profile="Gaming",
+        )
+        entity, *_ = _make_entity(PcRemoteMonitorProfileSelect, data)
+        assert entity.current_option == "Gaming"
 
     def test_unavailable_when_offline(self):
         data = make_coordinator_data(online=False)
@@ -124,14 +132,15 @@ class TestMonitorProfileSelect:
         assert entity.available is False
 
     @pytest.mark.asyncio
-    async def test_select_option_calls_api_and_refreshes(self):
+    async def test_select_option_calls_api_and_persists(self):
         data = make_coordinator_data(monitor_profiles=["Desktop", "Gaming"])
         entity, coordinator, client = _make_entity(PcRemoteMonitorProfileSelect, data)
 
         await entity.async_select_option("Gaming")
 
         client.set_monitor_profile.assert_awaited_once_with("Gaming")
-        coordinator.async_request_refresh.assert_awaited_once()
+        assert coordinator.data.current_monitor_profile == "Gaming"
+        coordinator.persist_selection.assert_awaited_once_with("monitor_profile", "Gaming")
 
     @pytest.mark.asyncio
     async def test_select_option_api_failure_propagates(self):
@@ -243,14 +252,15 @@ class TestModeSelect:
         assert entity.available is False
 
     @pytest.mark.asyncio
-    async def test_select_option_calls_api_and_stores_mode(self):
+    async def test_select_option_calls_api_and_persists_mode(self):
         data = make_coordinator_data(modes=["Gaming", "Work"])
         entity, coordinator, client = _make_entity(PcRemoteModeSelect, data)
 
         await entity.async_select_option("Gaming")
 
         client.set_mode.assert_awaited_once_with("Gaming")
-        assert entity.current_option == "Gaming"
+        assert coordinator.data.current_mode == "Gaming"
+        coordinator.persist_selection.assert_awaited_once_with("mode", "Gaming")
 
     @pytest.mark.asyncio
     async def test_select_option_updates_current_mode(self):
@@ -258,10 +268,10 @@ class TestModeSelect:
         entity, coordinator, client = _make_entity(PcRemoteModeSelect, data)
 
         await entity.async_select_option("Work")
-        assert entity.current_option == "Work"
+        assert coordinator.data.current_mode == "Work"
 
         await entity.async_select_option("Gaming")
-        assert entity.current_option == "Gaming"
+        assert coordinator.data.current_mode == "Gaming"
 
     @pytest.mark.asyncio
     async def test_select_option_api_failure_propagates(self):


### PR DESCRIPTION
## Summary
- **Mode/profile persistence**: selections stored via HA Store, restored on restart. Mode cleared when audio device changes externally. Stale values (no longer in available list) auto-cleared.
- **Wake-and-play simplified**: steam_run now returns SteamRunningGame dict (or None) from service. Reduced from 4 blind retries to max 2 attempts with server-side verification.
- **API update**: steam_run returns launch result dict instead of None
- **Docs**: README updated with v1.0 entities, blueprints, roadmap

## Test plan
- [x] 145 Python tests pass (14 new for persistence + invalidation)
- [ ] Manual test: select mode, restart HA, verify mode is restored
- [ ] Manual test: change audio device externally, verify mode clears
- [ ] Manual test: wake-and-play from offline state