### PR TITLE
Fix: CI, test scaffolding, and bug fixes

### DIFF
--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -131,7 +131,19 @@ still idle, then sleep the PC. Closes the power-saving loop without manual actio
 
 - [x] `blueprints/automation/pc_remote/post_session_sleep.yaml` *(integration)*
 
-### 5. User Idle Time Sensor
+### 5. Media Browser for Steam Games + Apps
+
+`select_source` works via developer tools / service calls but the dropdown only shows
+in the entity detail dialog — not on dashboard cards. Add `browse_media` + `play_media`
+support so Steam games (and later apps) appear in the HA media browser with thumbnails
+and hierarchical navigation.
+
+- [ ] Integration: implement `async_browse_media()` returning `BrowseMedia` tree *(integration)*
+- [ ] Integration: implement `async_play_media()` to launch games/apps *(integration)*
+- [ ] Integration: add `BROWSE_MEDIA` + `PLAY_MEDIA` feature flags *(integration)*
+- [ ] Integration: add tests for browse/play media *(integration)*
+
+### 6. User Idle Time Sensor
 
 `GetLastInputInfo` Win32 API → seconds since last keyboard/mouse input.
 Guards the sleep blueprint against sleeping a PC that someone is actively using at the desk.


### PR DESCRIPTION
## Summary
- Rewritten test scaffolding for real HA fixture compatibility
- Fixed steam_run error handling and wake-and-play target persistence
- Extracted select base class
- CI: added pytest asyncio_mode=auto, pull-requests write permission
- Added media browser to planned features

## Test plan
- [x] 145 tests pass locally