### PR TITLE
feat: idle time sensor + media browser (v1.0.2)

### DIFF
--- a/PLANNED_FEATURES.md
+++ b/PLANNED_FEATURES.md
@@ -131,22 +131,22 @@ still idle, then sleep the PC. Closes the power-saving loop without manual actio
 
 - [x] `blueprints/automation/pc_remote/post_session_sleep.yaml` *(integration)*
 
-### 5. Media Browser for Steam Games + Apps
+### 5. Media Browser for Steam Games + Apps *(done in v1.0.2)*
 
 `select_source` works via developer tools / service calls but the dropdown only shows
 in the entity detail dialog — not on dashboard cards. Add `browse_media` + `play_media`
 support so Steam games (and later apps) appear in the HA media browser with thumbnails
 and hierarchical navigation.
 
-- [ ] Integration: implement `async_browse_media()` returning `BrowseMedia` tree *(integration)*
-- [ ] Integration: implement `async_play_media()` to launch games/apps *(integration)*
-- [ ] Integration: add `BROWSE_MEDIA` + `PLAY_MEDIA` feature flags *(integration)*
-- [ ] Integration: add tests for browse/play media *(integration)*
+- [x] Integration: implement `async_browse_media()` returning `BrowseMedia` tree *(integration)*
+- [x] Integration: implement `async_play_media()` to launch games/apps *(integration)*
+- [x] Integration: add `BROWSE_MEDIA` + `PLAY_MEDIA` feature flags *(integration)*
+- [x] Integration: add tests for browse/play media *(integration)*
 
-### 6. User Idle Time Sensor
+### 6. User Idle Time Sensor *(done in v1.0.2)*
 
 `GetLastInputInfo` Win32 API → seconds since last keyboard/mouse input.
 Guards the sleep blueprint against sleeping a PC that someone is actively using at the desk.
 
-- [ ] Service: expose via `GET /api/system/idle` *(service)*
-- [ ] Integration: `sensor` entity "Idle Time" (device class `duration`) *(integration)*
+- [x] Service: expose via `GET /api/system/idle` *(service)*
+- [x] Integration: `sensor` entity "Idle Time" (device class `duration`) *(integration)*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Two ways to add the integration:
 | Volume | Number | Master volume (0-100) |
 | Monitor Profile | Select | Apply a saved `.cfg` monitor profile |
 | Active Monitor | Select | Switch to a single monitor (solo mode) |
-| Steam | Media Player | Launch Steam games; shows BUFFERING + wakes PC if offline |
+| Steam | Media Player | Launch Steam games via source list or media browser; wakes PC if offline |
+| Idle Time | Sensor | Seconds since last keyboard/mouse input on the PC |
 | {App Name} | Switch | Launch/kill configured apps |
 
 App switches are created dynamically based on apps configured in the service. PC Mode options come from the `Modes` config section.
@@ -57,7 +58,8 @@ Two automation blueprints are included:
 - [x] PC Mode select entity *(v1.0)*
 - [x] Aggregated state coordinator (single poll call) *(v1.0)*
 - [x] Couch Gaming + Post-Session Sleep blueprints *(v1.0)*
-- [ ] User Idle Time sensor *(v1.1)*
+- [x] User Idle Time sensor *(v1.0.2)*
+- [x] Steam media browser (browse + play) *(v1.0.2)*
 
 ## License
 

--- a/custom_components/pc_remote/__init__.py
+++ b/custom_components/pc_remote/__init__.py
@@ -17,6 +17,7 @@ PLATFORMS: list[Platform] = [
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 

--- a/custom_components/pc_remote/coordinator.py
+++ b/custom_components/pc_remote/coordinator.py
@@ -45,6 +45,7 @@ class PcRemoteData:
     modes: list[str] = field(default_factory=list)
     current_mode: str | None = None
     current_monitor_profile: str | None = None
+    idle_seconds: int | None = None
 
 
 class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
@@ -254,3 +255,4 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
         data.steam_games = state.get("steamGames", [])
         data.steam_running = state.get("runningGame")
         data.modes = state.get("modes", [])
+        data.idle_seconds = state.get("idleSeconds")

--- a/custom_components/pc_remote/manifest.json
+++ b/custom_components/pc_remote/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/NeskireDK/ha-pc-remote/issues",
   "requirements": ["wakeonlan==3.1.0"],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "zeroconf": [{"type": "_pc-remote._tcp.local."}]
 }

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -7,9 +7,12 @@ import logging
 from typing import Any
 
 from homeassistant.components.media_player import (
+    BrowseMedia,
+    MediaClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
+    MediaType,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -48,6 +51,8 @@ class PcRemoteSteamPlayer(
     _attr_supported_features = (
         MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
+        | MediaPlayerEntityFeature.PLAY_MEDIA
     )
 
     def __init__(
@@ -168,6 +173,75 @@ class PcRemoteSteamPlayer(
         await self._client.steam_stop()
         # Optimistic update, then refresh for consistency
         self.coordinator.data.steam_running = None
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_browse_media(
+        self,
+        media_content_type: MediaType | str | None = None,
+        media_content_id: str | None = None,
+    ) -> BrowseMedia:
+        """Return browsable Steam games."""
+        games = self.coordinator.data.steam_games
+        children = [
+            BrowseMedia(
+                media_class=MediaClass.GAME,
+                media_content_id=str(g.get("appId", "")),
+                media_content_type=MediaType.GAME,
+                title=g.get("name", "Unknown"),
+                can_play=True,
+                can_expand=False,
+                thumbnail=f"https://cdn.cloudflare.steamstatic.com/steam/apps/{g.get('appId', 0)}/header.jpg",
+            )
+            for g in games
+        ]
+        return BrowseMedia(
+            media_class=MediaClass.DIRECTORY,
+            media_content_id="steam_games",
+            media_content_type=MediaType.GAME,
+            title="Steam Games",
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
+
+    async def async_play_media(
+        self,
+        media_type: MediaType | str,
+        media_id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Launch a Steam game by app ID from the media browser."""
+        try:
+            app_id = int(media_id)
+        except (ValueError, TypeError):
+            _LOGGER.warning("Invalid media_id for Steam game: %s", media_id)
+            return
+
+        # Find the game name from the list for display
+        name = next(
+            (g.get("name", "") for g in self.coordinator.data.steam_games if g.get("appId") == app_id),
+            f"Game {app_id}",
+        )
+
+        if not self.coordinator.data.online:
+            if self._wake_task and not self._wake_task.done():
+                self._wake_task.cancel()
+            self._wake_target = {"appId": app_id, "name": name}
+            self.async_write_ha_state()
+            self._wake_task = self.hass.async_create_task(
+                self._wake_and_play(app_id, name)
+            )
+            return
+
+        try:
+            result = await self._client.steam_run(app_id)
+        except CannotConnectError as err:
+            _LOGGER.error("Failed to launch Steam game %d: %s", app_id, err)
+            return
+        self.coordinator.data.steam_running = (
+            result or {"appId": app_id, "name": name}
+        )
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/pc_remote/sensor.py
+++ b/custom_components/pc_remote/sensor.py
@@ -1,0 +1,72 @@
+"""Sensor platform for the PC Remote integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, build_device_info
+from .coordinator import PcRemoteCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the sensor platform."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: PcRemoteCoordinator = data["coordinator"]
+    async_add_entities([PcRemoteIdleSensor(coordinator, entry)])
+
+
+class PcRemoteIdleSensor(
+    CoordinatorEntity[PcRemoteCoordinator], SensorEntity
+):
+    """Sensor for user idle time on the remote PC."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "idle_time"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_icon = "mdi:timer-sand"
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        coordinator: PcRemoteCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the idle time sensor."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_idle_time"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info from latest coordinator data."""
+        return build_device_info(
+            self._entry,
+            machine_name=self.coordinator.data.machine_name,
+            sw_version=self.coordinator.data.service_version,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Only available when PC is online."""
+        return super().available and self.coordinator.data.online
+
+    @property
+    def native_value(self) -> int | None:
+        """Return idle seconds."""
+        return self.coordinator.data.idle_seconds

--- a/custom_components/pc_remote/strings.json
+++ b/custom_components/pc_remote/strings.json
@@ -9,6 +9,9 @@
       "active_monitor": { "name": "Active Monitor" },
       "pc_mode": { "name": "PC Mode" }
     },
+    "sensor": {
+      "idle_time": { "name": "Idle Time" }
+    },
     "number": {
       "volume": { "name": "Volume" }
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ def make_coordinator_data(**kwargs) -> PcRemoteData:
         modes=["Gaming", "Work", "TV"],
         current_mode=None,
         current_monitor_profile=None,
+        idle_seconds=30,
     )
     defaults.update(kwargs)
     return PcRemoteData(**defaults)

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -286,3 +286,104 @@ class TestEntityAttributes:
         player, *_ = _make_player()
         assert player._attr_supported_features & MediaPlayerEntityFeature.SELECT_SOURCE
         assert player._attr_supported_features & MediaPlayerEntityFeature.STOP
+
+    def test_supported_features_include_browse_and_play_media(self):
+        from homeassistant.components.media_player import MediaPlayerEntityFeature
+        player, *_ = _make_player()
+        assert player._attr_supported_features & MediaPlayerEntityFeature.BROWSE_MEDIA
+        assert player._attr_supported_features & MediaPlayerEntityFeature.PLAY_MEDIA
+
+
+# ---------------------------------------------------------------------------
+# async_browse_media
+# ---------------------------------------------------------------------------
+
+class TestBrowseMedia:
+    @pytest.mark.asyncio
+    async def test_returns_root_with_children(self):
+        games = [
+            {"appId": 570, "name": "Dota 2"},
+            {"appId": 1091500, "name": "Cyberpunk 2077"},
+        ]
+        data = make_coordinator_data(steam_games=games)
+        player, *_ = _make_player(data)
+
+        result = await player.async_browse_media()
+
+        assert result.title == "Steam Games"
+        assert result.can_expand is True
+        assert result.can_play is False
+        assert len(result.children) == 2
+
+    @pytest.mark.asyncio
+    async def test_children_have_game_properties(self):
+        games = [{"appId": 570, "name": "Dota 2"}]
+        data = make_coordinator_data(steam_games=games)
+        player, *_ = _make_player(data)
+
+        result = await player.async_browse_media()
+        child = result.children[0]
+
+        assert child.title == "Dota 2"
+        assert child.media_content_id == "570"
+        assert child.can_play is True
+        assert child.can_expand is False
+        assert "570" in child.thumbnail
+
+    @pytest.mark.asyncio
+    async def test_empty_games_returns_empty_children(self):
+        data = make_coordinator_data(steam_games=[])
+        player, *_ = _make_player(data)
+
+        result = await player.async_browse_media()
+
+        assert result.children == []
+
+
+# ---------------------------------------------------------------------------
+# async_play_media
+# ---------------------------------------------------------------------------
+
+class TestPlayMedia:
+    @pytest.mark.asyncio
+    async def test_launches_game_by_app_id(self):
+        games = [{"appId": 570, "name": "Dota 2"}]
+        data = make_coordinator_data(online=True, steam_games=games)
+        player, coordinator, client = _make_player(data)
+        client.steam_run = AsyncMock(return_value={"appId": 570, "name": "Dota 2"})
+
+        await player.async_play_media("game", "570")
+
+        client.steam_run.assert_awaited_once_with(570)
+        assert coordinator.data.steam_running == {"appId": 570, "name": "Dota 2"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_media_id_does_nothing(self):
+        player, coordinator, client = _make_player()
+
+        await player.async_play_media("game", "not-a-number")
+
+        client.steam_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_offline_triggers_wake_and_play(self):
+        games = [{"appId": 570, "name": "Dota 2"}]
+        data = make_coordinator_data(online=False, steam_games=games)
+        player, coordinator, client = _make_player(data)
+        coordinator.hass.async_create_task = MagicMock()
+
+        await player.async_play_media("game", "570")
+
+        assert player._wake_target == {"appId": 570, "name": "Dota 2"}
+        coordinator.hass.async_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_launch_failure_does_not_raise(self):
+        games = [{"appId": 570, "name": "Dota 2"}]
+        data = make_coordinator_data(online=True, steam_games=games)
+        player, coordinator, client = _make_player(data)
+        client.steam_run.side_effect = CannotConnectError("refused")
+
+        await player.async_play_media("game", "570")
+
+        assert coordinator.data.steam_running is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,61 @@
+"""Tests for the PC Remote sensor platform."""
+
+from __future__ import annotations
+
+from tests.conftest import (
+    make_coordinator_data,
+    make_mock_coordinator,
+    make_mock_entry,
+    wire_entity,
+)
+
+from custom_components.pc_remote.sensor import PcRemoteIdleSensor
+
+
+class TestIdleSensor:
+    """Tests for PcRemoteIdleSensor."""
+
+    def _make_sensor(self, coordinator=None, entry=None):
+        entry = entry or make_mock_entry()
+        coordinator = coordinator or make_mock_coordinator()
+        sensor = PcRemoteIdleSensor(coordinator, entry)
+        wire_entity(sensor, coordinator)
+        return sensor
+
+    def test_native_value_returns_idle_seconds(self):
+        data = make_coordinator_data(idle_seconds=120)
+        coordinator = make_mock_coordinator(data)
+        sensor = self._make_sensor(coordinator=coordinator)
+        assert sensor.native_value == 120
+
+    def test_native_value_none_when_not_available(self):
+        data = make_coordinator_data(idle_seconds=None)
+        coordinator = make_mock_coordinator(data)
+        sensor = self._make_sensor(coordinator=coordinator)
+        assert sensor.native_value is None
+
+    def test_available_when_online(self):
+        data = make_coordinator_data(online=True)
+        coordinator = make_mock_coordinator(data)
+        sensor = self._make_sensor(coordinator=coordinator)
+        assert sensor.available is True
+
+    def test_unavailable_when_offline(self):
+        data = make_coordinator_data(online=False)
+        coordinator = make_mock_coordinator(data)
+        sensor = self._make_sensor(coordinator=coordinator)
+        assert sensor.available is False
+
+    def test_unique_id(self):
+        sensor = self._make_sensor()
+        assert sensor.unique_id == "test_entry_id_idle_time"
+
+    def test_device_class(self):
+        from homeassistant.components.sensor import SensorDeviceClass
+        sensor = self._make_sensor()
+        assert sensor.device_class == SensorDeviceClass.DURATION
+
+    def test_native_unit(self):
+        from homeassistant.const import UnitOfTime
+        sensor = self._make_sensor()
+        assert sensor.native_unit_of_measurement == UnitOfTime.SECONDS


### PR DESCRIPTION
## Summary
- Add Idle Time sensor entity (device_class=duration, seconds)
- Add Steam media browser (async_browse_media with thumbnails from Steam CDN)
- Add async_play_media for launching games from the media browser
- Games browsable via HA media browser panel with artwork
- Version bump to 1.0.2

## Test plan
- [x] 160 tests pass locally (15 new: 7 sensor + 4 browse + 4 play)