### PR TITLE
refactor: v1.0.3 code review fixes

### DIFF
--- a/custom_components/pc_remote/coordinator.py
+++ b/custom_components/pc_remote/coordinator.py
@@ -118,22 +118,20 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
                 data.online = expected
                 data.steam_games = list(self._cached_steam_games)
                 return data
-            else:
-                self._power_override = None
+            self._power_override = None
 
-        if self._power_override is None:
-            # Check health
-            try:
-                health = await self.client.get_health()
-                data.online = True
-                data.machine_name = health.get("machineName", "")
-                data.service_version = health.get("version", "")
-            except CannotConnectError:
-                data.online = False
-            except InvalidAuthError as err:
-                raise ConfigEntryAuthFailed("Invalid API key") from err
-            except Exception as err:  # noqa: BLE001
-                raise UpdateFailed(f"Unexpected error: {err}") from err
+        # Check health
+        try:
+            health = await self.client.get_health()
+            data.online = True
+            data.machine_name = health.get("machineName", "")
+            data.service_version = health.get("version", "")
+        except CannotConnectError:
+            data.online = False
+        except InvalidAuthError as err:
+            raise ConfigEntryAuthFailed("Invalid API key") from err
+        except Exception as err:  # noqa: BLE001
+            raise UpdateFailed(f"Unexpected error: {err}") from err
 
         if not data.online:
             # Serve the last known game list so the source_list remains populated

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -79,11 +79,6 @@ class PcRemoteSteamPlayer(
         )
 
     @property
-    def available(self) -> bool:
-        """Always available — source list is shown even when PC is offline."""
-        return super().available
-
-    @property
     def state(self) -> MediaPlayerState:
         """Return the state of the media player."""
         if self._wake_target is not None:
@@ -141,28 +136,9 @@ class PcRemoteSteamPlayer(
             if game.get("name") == source:
                 app_id = game.get("appId")
                 if app_id is None:
-                    _LOGGER.warning("Source '%s' not found in steam games list", source)
+                    _LOGGER.warning("Source '%s' has no appId", source)
                     return
-                if not self.coordinator.data.online:
-                    if self._wake_task and not self._wake_task.done():
-                        self._wake_task.cancel()
-                    self._wake_target = {"appId": app_id, "name": source}
-                    self.async_write_ha_state()
-                    self._wake_task = self.hass.async_create_task(
-                        self._wake_and_play(app_id, source)
-                    )
-                    return
-                try:
-                    result = await self._client.steam_run(app_id)
-                except CannotConnectError as err:
-                    _LOGGER.error("Failed to launch Steam game '%s': %s", source, err)
-                    return
-                # Optimistic update, then schedule a refresh for consistency
-                self.coordinator.data.steam_running = (
-                    result or {"appId": app_id, "name": source}
-                )
-                self.async_write_ha_state()
-                await self.coordinator.async_request_refresh()
+                await self._launch_or_wake(app_id, source)
                 return
         _LOGGER.warning("Steam game not found in list: %s", source)
 
@@ -171,7 +147,6 @@ class PcRemoteSteamPlayer(
         if not self.coordinator.data.online:
             return
         await self._client.steam_stop()
-        # Optimistic update, then refresh for consistency
         self.coordinator.data.steam_running = None
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
@@ -218,12 +193,14 @@ class PcRemoteSteamPlayer(
             _LOGGER.warning("Invalid media_id for Steam game: %s", media_id)
             return
 
-        # Find the game name from the list for display
         name = next(
             (g.get("name", "") for g in self.coordinator.data.steam_games if g.get("appId") == app_id),
             f"Game {app_id}",
         )
+        await self._launch_or_wake(app_id, name)
 
+    async def _launch_or_wake(self, app_id: int, name: str) -> None:
+        """Launch a game, or wake the PC first if offline."""
         if not self.coordinator.data.online:
             if self._wake_task and not self._wake_task.done():
                 self._wake_task.cancel()
@@ -237,7 +214,7 @@ class PcRemoteSteamPlayer(
         try:
             result = await self._client.steam_run(app_id)
         except CannotConnectError as err:
-            _LOGGER.error("Failed to launch Steam game %d: %s", app_id, err)
+            _LOGGER.error("Failed to launch Steam game '%s': %s", name, err)
             return
         self.coordinator.data.steam_running = (
             result or {"appId": app_id, "name": name}


### PR DESCRIPTION
## Summary
- Extract `_launch_or_wake()` method — deduplicates wake-and-play logic from `async_select_source` and `async_play_media`
- Remove pointless `available` property override that just called `super()`
- Remove redundant `power_override is None` check in coordinator
- Fix indentation in coordinator health check block

## Test plan
- [x] 160 integration tests passing
- [ ] Verify wake-and-play still works via both source select and media browser