### PR TITLE
feat: v1.2.2 Steam cold-start, game-to-PC-mode binding, local artwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 *~
 .DS_Store
 Thumbs.db
+.idea/


### PR DESCRIPTION
## Summary
- Steam cold-start support: poll `steam_ready` before launching games, auto-launch Steam if not running
- Game-to-PC-mode binding: coordinate mode switches with game launches
- Local artwork endpoint: media browser thumbnails served from local cache instead of Steam CDN
- Bump integration version to 1.2.2

## Test plan
- [ ] Verify Steam cold-start polling works end-to-end with service v1.2.2
- [ ] Verify game-to-PC-mode binding switches mode before launching game
- [ ] Verify media browser thumbnails load from local endpoint