### PR TITLE
fix: slide stop hold window while service still reports game running

### DIFF
--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -101,9 +101,19 @@ class PcRemoteSteamPlayer(
         if not self.coordinator.data.online:
             return MediaPlayerState.OFF
         if self.coordinator.data.steam_running:
+            # If a stop was issued, the service still reporting a running game
+            # means the process has not exited yet. Slide the hold window
+            # forward so it does not expire while the game is still dying, and
+            # suppress the _last_playing refresh so the window does not get
+            # confused about which game was last seen.
+            if self._stop_issued_at is not None:
+                self._stop_issued_at = dt_util.utcnow()
+                return MediaPlayerState.PLAYING
             self._last_playing = self.coordinator.data.steam_running
             return MediaPlayerState.PLAYING
-        # Hold optimistic playing state for 30 s after a stop command
+        # Hold optimistic playing state for 30 s after a stop command, to
+        # absorb the poll-cycle lag between the game exiting and the service
+        # confirming it is gone.
         if self._in_stop_hold_window():
             return MediaPlayerState.PLAYING
         return MediaPlayerState.IDLE

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -379,6 +379,66 @@ class TestMediaStop:
 
         client.steam_stop.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_stop_sets_stop_issued_at(self):
+        """async_media_stop records the timestamp so the hold window is active."""
+        data = make_coordinator_data(online=True, steam_running={"appId": 570, "name": "Dota 2"})
+        player, coordinator, client = _make_player(data)
+
+        assert player._stop_issued_at is None
+        await player.async_media_stop()
+        assert player._stop_issued_at is not None
+
+    def test_state_sliding_window_while_service_still_reports_running(self):
+        """When stop was issued but service still reports game running, the hold
+        window is extended (stop_issued_at is refreshed) so the window never
+        expires while the process is still alive."""
+        from homeassistant.util import dt as dt_util
+        from datetime import timedelta
+
+        data = make_coordinator_data(online=True, steam_running={"appId": 570, "name": "Dota 2"})
+        player, coordinator, client = _make_player(data)
+
+        # Simulate stop issued 29 s ago — window is about to expire
+        old_ts = dt_util.utcnow() - timedelta(seconds=29)
+        player._stop_issued_at = old_ts
+
+        # Coordinator still reports the game as running
+        coordinator.data.steam_running = {"appId": 570, "name": "Dota 2"}
+
+        state = player.state
+
+        assert state == MediaPlayerState.PLAYING
+        # stop_issued_at must have been slid forward (refreshed to ~now)
+        assert player._stop_issued_at > old_ts
+
+    def test_state_stop_hold_window_active_after_game_exits(self):
+        """Once service reports game gone, the 30 s hold window takes over so
+        HA does not immediately flip to IDLE before the next poll confirms."""
+        from homeassistant.util import dt as dt_util
+
+        data = make_coordinator_data(online=True, steam_running=None)
+        player, coordinator, client = _make_player(data)
+
+        # Stop was issued 5 s ago; service now reports no game running
+        player._stop_issued_at = dt_util.utcnow()
+        player._last_playing = {"appId": 570, "name": "Dota 2"}
+
+        assert player.state == MediaPlayerState.PLAYING
+
+    def test_state_normal_playing_does_not_touch_stop_issued_at(self):
+        """Without a stop in progress, state=PLAYING refreshes _last_playing
+        and leaves _stop_issued_at untouched (None)."""
+        data = make_coordinator_data(online=True, steam_running={"appId": 570, "name": "Dota 2"})
+        player, coordinator, client = _make_player(data)
+
+        assert player._stop_issued_at is None
+        state = player.state
+
+        assert state == MediaPlayerState.PLAYING
+        assert player._last_playing == {"appId": 570, "name": "Dota 2"}
+        assert player._stop_issued_at is None
+
 
 # ---------------------------------------------------------------------------
 # Unique ID and features


### PR DESCRIPTION
## Root cause

The 30s stop hold window expired while the game was still running.

When `async_media_stop` fires:
1. `_stop_issued_at` is set, `coordinator.data.steam_running` is cleared optimistically.
2. The coordinator polls every 30s. If the game process is still alive, the next poll sets `steam_running` back to the running game.
3. In `state`, the `coordinator.data.steam_running` branch executes first — it refreshes `_last_playing` and returns `PLAYING`, bypassing the hold window entirely.
4. At ~30s `_stop_issued_at` is now expired. If the game finally exits at e.g. 45s, `_last_playing` was still being refreshed, so state never entered the hold window path and flipped straight to IDLE when the process finally died.

The underlying issue: the hold window was designed to cover polling lag after the game exits, not to cover slow game shutdown. For slow games the window expired while the service still reported the game alive.

## Fix

In `state`, when `_stop_issued_at` is set and the coordinator still reports a game running (process not yet dead), slide `_stop_issued_at` forward to `utcnow()`. This keeps the window alive for as long as the process is alive. The 30s countdown only begins once the service confirms the game is gone, which is exactly what the window was designed for.

`_last_playing` is not refreshed during the slide, preventing the game-stopping metadata from being overwritten.

## Tests

- `test_stop_sets_stop_issued_at` — stop records timestamp
- `test_state_sliding_window_while_service_still_reports_running` — window is extended, old timestamp replaced
- `test_state_stop_hold_window_active_after_game_exits` — 30s window holds after service confirms exit
- `test_state_normal_playing_does_not_touch_stop_issued_at` — normal play path unaffected

All 7 stop-related tests pass (28 sync, 0 failures).