### PR TITLE
Mock asyncio.sleep in tests to fix 12-min CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,13 @@ def _mock_store():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _mock_asyncio_sleep():
+    """Make asyncio.sleep a no-op so WoL loops and poll waits run instantly."""
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds autouse `_mock_asyncio_sleep` fixture in `conftest.py` that patches `asyncio.sleep` as a no-op
- Eliminates real waits in WoL sustained send loop (20s) and wake-and-play polling (up to 3 min)
- CI drops from ~12 min to ~30s

## Test plan
- [x] Full test suite passes (231 tests in 30s)
- [x] No test logic changed — only sleep timing removed

Closes #25