### PR TITLE
Release 1.7.1

### DIFF
--- a/custom_components/pc_remote/__init__.py
+++ b/custom_components/pc_remote/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     scan_interval = entry.options.get("scan_interval", DEFAULT_SCAN_INTERVAL)
-    coordinator = PcRemoteCoordinator(hass, client, entry.entry_id, scan_interval)
+    coordinator = PcRemoteCoordinator(hass, client, entry, scan_interval)
     await coordinator.async_load_steam_cache()
     await coordinator.load_selections()
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/pc_remote/button.py
+++ b/custom_components/pc_remote/button.py
@@ -6,13 +6,12 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import PcRemoteClient
-from .const import DOMAIN, build_device_info
+from .const import DOMAIN
 from .coordinator import PcRemoteCoordinator
+from .entity_base import PcRemoteEntityBase
 
 
 async def async_setup_entry(
@@ -27,9 +26,7 @@ async def async_setup_entry(
     async_add_entities([PcRemoteUpdateButton(coordinator, client, entry)])
 
 
-class PcRemoteUpdateButton(
-    CoordinatorEntity[PcRemoteCoordinator], ButtonEntity
-):
+class PcRemoteUpdateButton(PcRemoteEntityBase, ButtonEntity):
     """Button to trigger service update check."""
 
     _attr_has_entity_name = True
@@ -44,19 +41,9 @@ class PcRemoteUpdateButton(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the update button."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_check_update"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/pc_remote/coordinator.py
+++ b/custom_components/pc_remote/coordinator.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
 import time
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from wakeonlan import send_magic_packet
 
 from .api import CannotConnectError, InvalidAuthError, PcRemoteClient
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import CONF_MAC_ADDRESS, DEFAULT_SCAN_INTERVAL, DOMAIN, FAST_POLL_DURATION, FAST_POLL_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +28,8 @@ STEAM_GAMES_STORAGE_VERSION = 1
 
 
 SELECTIONS_STORAGE_VERSION = 1
+
+_WAKE_RETRY_COUNT = 36  # 36 * 5s = 3 min
 
 
 @dataclass
@@ -56,7 +61,7 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
         self,
         hass: HomeAssistant,
         client: PcRemoteClient,
-        entry_id: str,
+        entry: ConfigEntry,
         scan_interval: int = DEFAULT_SCAN_INTERVAL,
     ) -> None:
         """Initialize the coordinator."""
@@ -67,19 +72,89 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
             update_interval=timedelta(seconds=scan_interval),
         )
         self.client = client
+        self.entry = entry
+        self._scan_interval = scan_interval
+        self._fast_polling = False
+        self._fast_poll_start: float = 0
+        self._wake_task: asyncio.Task[bool] | None = None
         self._power_override: tuple[bool, float] | None = None
         self._steam_games_store: Store = Store(
             hass,
             STEAM_GAMES_STORAGE_VERSION,
-            f"{DOMAIN}.{entry_id}.steam_games",
+            f"{DOMAIN}.{entry.entry_id}.steam_games",
         )
         self._cached_steam_games: list[dict] = []
         self._selections_store: Store = Store(
             hass,
             SELECTIONS_STORAGE_VERSION,
-            f"{DOMAIN}.{entry_id}.selections",
+            f"{DOMAIN}.{entry.entry_id}.selections",
         )
         self._prev_audio_device: str | None = None
+
+    # ── Wake-on-LAN ───────────────────────────────────────────────────
+
+    async def async_ensure_online(self) -> bool:
+        """Wake the PC if offline. Returns True if online, False if wake failed.
+
+        Concurrent callers share a single wake task to avoid thundering herd.
+        """
+        if self.data.online:
+            return True
+        return await self.async_wake_and_wait()
+
+    async def async_wake_and_wait(self) -> bool:
+        """Send sustained WoL and wait for service to come online (max 3 min).
+
+        Concurrent callers share a single wake task.
+        """
+        if self._wake_task and not self._wake_task.done():
+            return await self._wake_task
+        self._wake_task = asyncio.ensure_future(self._do_wake())
+        return await self._wake_task
+
+    async def _do_wake(self) -> bool:
+        """Internal wake implementation."""
+        mac = self.entry.data.get(CONF_MAC_ADDRESS)
+        if not mac:
+            _LOGGER.error("MAC address not configured, cannot send WoL packet")
+            return False
+        self.set_power_state(True)
+        await self._send_wol_sustained(mac)
+        self._start_fast_poll()
+        for _ in range(_WAKE_RETRY_COUNT):
+            await asyncio.sleep(5)
+            try:
+                await self.client.get_health()
+                return True
+            except CannotConnectError:
+                continue
+        self._restore_normal_poll()
+        _LOGGER.warning("PC did not come online within timeout")
+        return False
+
+    async def _send_wol_sustained(self, mac: str, duration: int = 20, interval: int = 1) -> None:
+        """Send WoL magic packets repeatedly for `duration` seconds."""
+        end_time = time.monotonic() + duration
+        while time.monotonic() < end_time:
+            try:
+                await self.hass.async_add_executor_job(send_magic_packet, mac)
+            except (ValueError, OSError) as err:
+                _LOGGER.error("Failed to send WoL packet: %s", err)
+                return
+            await asyncio.sleep(interval)
+
+    def _start_fast_poll(self) -> None:
+        """Switch to fast polling temporarily."""
+        self._fast_polling = True
+        self._fast_poll_start = time.monotonic()
+        self.update_interval = timedelta(seconds=FAST_POLL_INTERVAL)
+
+    def _restore_normal_poll(self) -> None:
+        """Restore normal polling interval."""
+        self._fast_polling = False
+        self.update_interval = timedelta(seconds=self._scan_interval)
+
+    # ── Storage ────────────────────────────────────────────────────────
 
     async def async_load_steam_cache(self) -> None:
         """Load persisted Steam game list from storage. Call before first refresh."""
@@ -136,9 +211,16 @@ class PcRemoteCoordinator(DataUpdateCoordinator[PcRemoteData]):
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
         if not data.online:
+            # Expire fast polling if the duration has elapsed (avoids 1s polling forever)
+            if self._fast_polling and time.monotonic() - self._fast_poll_start > FAST_POLL_DURATION:
+                self._restore_normal_poll()
             # Serve the last known game list so the source_list remains populated
             data.steam_games = list(self._cached_steam_games)
             return data
+
+        # Restore normal polling if we were fast-polling and PC came online
+        if self._fast_polling:
+            self._restore_normal_poll()
 
         # Try aggregated state endpoint first
         try:

--- a/custom_components/pc_remote/entity_base.py
+++ b/custom_components/pc_remote/entity_base.py
@@ -1,0 +1,32 @@
+"""Base entity class for PC Remote integration entities."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import build_device_info
+from .coordinator import PcRemoteCoordinator
+
+
+class PcRemoteEntityBase(CoordinatorEntity[PcRemoteCoordinator]):
+    """Shared base for all PC Remote entities that need device_info."""
+
+    def __init__(
+        self,
+        coordinator: PcRemoteCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize with coordinator and config entry."""
+        super().__init__(coordinator)
+        self._entry = entry
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info from latest coordinator data."""
+        return build_device_info(
+            self._entry,
+            machine_name=self.coordinator.data.machine_name,
+            sw_version=self.coordinator.data.service_version,
+        )

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -363,6 +363,7 @@ class PcRemoteSteamPlayer(PcRemoteEntityBase, MediaPlayerEntity):
         media_content_id: str | None = None,
     ) -> BrowseMedia:
         """Return browsable Steam games."""
+        await self.coordinator.async_request_refresh()
         games = self.coordinator.data.steam_games
         children = [
             BrowseMedia(

--- a/custom_components/pc_remote/media_player.py
+++ b/custom_components/pc_remote/media_player.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 import os
 from typing import Any
@@ -19,25 +19,17 @@ from homeassistant.components.media_player import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
-from collections.abc import Callable
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
-from wakeonlan import send_magic_packet
 
 from .api import CannotConnectError, PcRemoteClient
 from .const import (
     CONF_HOST,
-    CONF_MAC_ADDRESS,
     CONF_PORT,
     DOMAIN,
-    FAST_POLL_DURATION,
-    FAST_POLL_INTERVAL,
-    build_device_info,
 )
 from .coordinator import PcRemoteCoordinator
+from .entity_base import PcRemoteEntityBase
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,9 +50,7 @@ async def async_setup_entry(
     async_add_entities([PcRemoteSteamPlayer(coordinator, client, entry)])
 
 
-class PcRemoteSteamPlayer(
-    CoordinatorEntity[PcRemoteCoordinator], MediaPlayerEntity
-):
+class PcRemoteSteamPlayer(PcRemoteEntityBase, MediaPlayerEntity):
     """Media player entity for Steam game control."""
 
     _attr_has_entity_name = True
@@ -83,24 +73,13 @@ class PcRemoteSteamPlayer(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the media player entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_steam"
         self._wake_target: dict | None = None
         self._wake_task: asyncio.Task | None = None
         self._stop_issued_at: datetime | None = None
         self._last_playing: dict | None = None
-        self._fast_poll_unsub: Callable | None = None
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     def _in_stop_hold_window(self) -> bool:
         """Return True if we are within 30 s of a stop command being issued."""
@@ -110,21 +89,16 @@ class PcRemoteSteamPlayer(
 
     @property
     def state(self) -> MediaPlayerState:
-        """Return the state of the media player."""
+        """Return the state of the media player.
+
+        This property is pure — it reads pre-computed instance variables set by
+        _handle_coordinator_update and mutates nothing.
+        """
         if self._wake_target is not None:
             return MediaPlayerState.BUFFERING
         if not self.coordinator.data.online:
             return MediaPlayerState.OFF
         if self.coordinator.data.steam_running:
-            # If a stop was issued, the service still reporting a running game
-            # means the process has not exited yet. Slide the hold window
-            # forward so it does not expire while the game is still dying, and
-            # suppress the _last_playing refresh so the window does not get
-            # confused about which game was last seen.
-            if self._stop_issued_at is not None:
-                self._stop_issued_at = dt_util.utcnow()
-                return MediaPlayerState.PLAYING
-            self._last_playing = self.coordinator.data.steam_running
             return MediaPlayerState.PLAYING
         # Hold optimistic playing state for 30 s after a stop command, to
         # absorb the poll-cycle lag between the game exiting and the service
@@ -313,49 +287,36 @@ class PcRemoteSteamPlayer(
 
         return await self.hass.async_add_executor_job(_read)
 
-    def _start_fast_poll(self) -> None:
-        """Switch coordinator to fast polling and schedule restoration."""
-        if self._fast_poll_unsub is not None:
-            self._fast_poll_unsub()
-        self.coordinator.update_interval = timedelta(seconds=FAST_POLL_INTERVAL)
-
-        def _restore_callback(_now: Any) -> None:
-            self._restore_normal_poll()
-
-        self._fast_poll_unsub = async_call_later(
-            self.hass, FAST_POLL_DURATION, _restore_callback
-        )
-
-    def _restore_normal_poll(self) -> None:
-        """Restore the coordinator to its normal polling interval."""
-        from .const import DEFAULT_SCAN_INTERVAL
-
-        self.coordinator.update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
-        if self._fast_poll_unsub is not None:
-            self._fast_poll_unsub()
-            self._fast_poll_unsub = None
-
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        if (
-            self._fast_poll_unsub is not None
-            and self.coordinator.data.online
-        ):
-            self._restore_normal_poll()
+        """Handle updated data from the coordinator.
+
+        Called once per coordinator refresh. Mutates stop-hold and last-playing
+        state here so that the state property remains side-effect-free.
+        """
+        if self.coordinator.data.steam_running:
+            # If a stop was issued, the service still reporting a running game
+            # means the process has not exited yet. Slide the hold window
+            # forward so it does not expire while the game is still dying, and
+            # suppress the _last_playing refresh so the window does not get
+            # confused about which game was last seen.
+            if self._stop_issued_at is not None:
+                self._stop_issued_at = dt_util.utcnow()
+            else:
+                self._last_playing = self.coordinator.data.steam_running
+
         super()._handle_coordinator_update()
 
     async def async_will_remove_from_hass(self) -> None:
-        """Cancel any pending wake-and-play task and fast poll timer on removal."""
+        """Cancel any pending wake-and-play task on removal."""
         if self._wake_task and not self._wake_task.done():
             self._wake_task.cancel()
-        if self._fast_poll_unsub is not None:
-            self._fast_poll_unsub()
-            self._fast_poll_unsub = None
         await super().async_will_remove_from_hass()
 
     async def async_select_source(self, source: str) -> None:
         """Launch the selected game."""
         if source == BIG_PICTURE_SOURCE:
+            if not await self.coordinator.async_ensure_online():
+                return
             await self._client.launch_app("steam-bigpicture")
             return
         for game in self.coordinator.data.steam_games:
@@ -368,43 +329,12 @@ class PcRemoteSteamPlayer(
                 return
         _LOGGER.warning("Steam game not found in list: %s", source)
 
-    async def _send_wol_sustained(self, mac: str, duration: int = 20, interval: int = 1) -> None:
-        """Send WoL magic packets repeatedly for `duration` seconds."""
-        end_time = dt_util.utcnow().timestamp() + duration
-        while dt_util.utcnow().timestamp() < end_time:
-            try:
-                await self.hass.async_add_executor_job(send_magic_packet, mac)
-            except (ValueError, OSError) as err:
-                _LOGGER.error("Failed to send WoL packet: %s", err)
-                return
-            await asyncio.sleep(interval)
-
-    async def _wake_and_wait(self) -> bool:
-        """Send sustained WoL and wait for service to come online (max 3 min)."""
-        mac = self._entry.data.get(CONF_MAC_ADDRESS)
-        if not mac:
-            _LOGGER.error("MAC address not configured, cannot send WoL packet")
-            return False
-        self.coordinator.set_power_state(True)
-        self.async_write_ha_state()
-        await self._send_wol_sustained(mac)
-        self._start_fast_poll()
-        for _ in range(36):  # 36 * 5s = 3 min
-            await asyncio.sleep(5)
-            try:
-                await self._client.get_health()
-                return True
-            except CannotConnectError:
-                continue
-        _LOGGER.warning("PC did not come online within timeout")
-        return False
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Wake the PC via Wake-on-LAN (sustained retry + health poll)."""
         self._wake_target = {"appId": 0, "name": "Waking PC..."}
         self.async_write_ha_state()
         try:
-            await self._wake_and_wait()
+            await self.coordinator.async_wake_and_wait()
         finally:
             self._wake_target = None
             self.async_write_ha_state()
@@ -476,6 +406,8 @@ class PcRemoteSteamPlayer(
     ) -> None:
         """Launch a Steam game by app ID from the media browser."""
         if media_id == "steam-bigpicture":
+            if not await self.coordinator.async_ensure_online():
+                return
             await self._client.launch_app("steam-bigpicture")
             return
         try:
@@ -527,7 +459,7 @@ class PcRemoteSteamPlayer(
         target = {"appId": app_id, "name": source}
         self._wake_target = target
 
-        online = await self._wake_and_wait()
+        online = await self.coordinator.async_wake_and_wait()
         if not online:
             self._wake_target = None
             self.async_write_ha_state()

--- a/custom_components/pc_remote/number.py
+++ b/custom_components/pc_remote/number.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import PcRemoteClient
-from .const import DOMAIN, build_device_info
+from .const import DOMAIN
 from .coordinator import PcRemoteCoordinator
+from .entity_base import PcRemoteEntityBase
 
 
 async def async_setup_entry(
@@ -29,9 +28,7 @@ async def async_setup_entry(
     ])
 
 
-class PcRemoteVolumeNumber(
-    CoordinatorEntity[PcRemoteCoordinator], NumberEntity
-):
+class PcRemoteVolumeNumber(PcRemoteEntityBase, NumberEntity):
     """Number entity for controlling the system volume."""
 
     _attr_has_entity_name = True
@@ -48,19 +45,9 @@ class PcRemoteVolumeNumber(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_volume"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     @property
     def available(self) -> bool:
@@ -79,9 +66,7 @@ class PcRemoteVolumeNumber(
         self.async_write_ha_state()
 
 
-class PcRemoteAutoSleepNumber(
-    CoordinatorEntity[PcRemoteCoordinator], NumberEntity
-):
+class PcRemoteAutoSleepNumber(PcRemoteEntityBase, NumberEntity):
     """Number entity for configuring auto-sleep timeout."""
 
     _attr_has_entity_name = True
@@ -99,19 +84,9 @@ class PcRemoteAutoSleepNumber(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_auto_sleep"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/pc_remote/select.py
+++ b/custom_components/pc_remote/select.py
@@ -7,13 +7,12 @@ import logging
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import PcRemoteClient
-from .const import DOMAIN, build_device_info
+from .const import DOMAIN
 from .coordinator import PcRemoteCoordinator
+from .entity_base import PcRemoteEntityBase
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,9 +33,7 @@ async def async_setup_entry(
     ])
 
 
-class PcRemoteSelectBase(
-    CoordinatorEntity[PcRemoteCoordinator], SelectEntity
-):
+class PcRemoteSelectBase(PcRemoteEntityBase, SelectEntity):
     """Base class for PC Remote select entities."""
 
     _attr_has_entity_name = True
@@ -49,24 +46,9 @@ class PcRemoteSelectBase(
         unique_id_suffix: str,
     ) -> None:
         """Initialize the select entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_{unique_id_suffix}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
-
-    @property
-    def available(self) -> bool:
-        """Available only when the PC is online."""
-        return super().available and self.coordinator.data.online
 
 
 class PcRemoteAudioOutputSelect(PcRemoteSelectBase):
@@ -95,7 +77,9 @@ class PcRemoteAudioOutputSelect(PcRemoteSelectBase):
         return self.coordinator.data.current_audio_device
 
     async def async_select_option(self, option: str) -> None:
-        """Set the audio output device."""
+        """Set the audio output device, waking the PC first if needed."""
+        if not await self.coordinator.async_ensure_online():
+            return
         await self._client.set_audio_device(option)
         self.coordinator.data.current_audio_device = option
         self.async_write_ha_state()
@@ -140,7 +124,9 @@ class PcRemoteMonitorSoloSelect(PcRemoteSelectBase):
         return None
 
     async def async_select_option(self, option: str) -> None:
-        """Solo the selected monitor."""
+        """Solo the selected monitor, waking the PC first if needed."""
+        if not await self.coordinator.async_ensure_online():
+            return
         monitor_id = self._monitor_id_for_name(option)
         if monitor_id is None:
             _LOGGER.warning("Monitor '%s' not found in known monitors", option)
@@ -175,7 +161,9 @@ class PcRemoteModeSelect(PcRemoteSelectBase):
         return self.coordinator.data.current_mode
 
     async def async_select_option(self, option: str) -> None:
-        """Apply the selected PC mode."""
+        """Apply the selected PC mode, waking the PC first if needed."""
+        if not await self.coordinator.async_ensure_online():
+            return
         await self._client.set_mode(option)
         self.coordinator.data.current_mode = option
         await self.coordinator.persist_selection("mode", option)

--- a/custom_components/pc_remote/sensor.py
+++ b/custom_components/pc_remote/sensor.py
@@ -10,12 +10,11 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, build_device_info
+from .const import DOMAIN
 from .coordinator import PcRemoteCoordinator
+from .entity_base import PcRemoteEntityBase
 
 
 async def async_setup_entry(
@@ -32,9 +31,7 @@ async def async_setup_entry(
     ])
 
 
-class PcRemoteIdleSensor(
-    CoordinatorEntity[PcRemoteCoordinator], SensorEntity
-):
+class PcRemoteIdleSensor(PcRemoteEntityBase, SensorEntity):
     """Sensor for user idle duration on the remote PC."""
 
     _attr_has_entity_name = True
@@ -51,18 +48,8 @@ class PcRemoteIdleSensor(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the idle duration sensor."""
-        super().__init__(coordinator)
-        self._entry = entry
+        super().__init__(coordinator, entry)
         self._attr_unique_id = f"{entry.entry_id}_idle_duration"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     @property
     def available(self) -> bool:
@@ -75,9 +62,7 @@ class PcRemoteIdleSensor(
         return self.coordinator.data.idle_seconds
 
 
-class PcRemoteVersionSensor(
-    CoordinatorEntity[PcRemoteCoordinator], SensorEntity
-):
+class PcRemoteVersionSensor(PcRemoteEntityBase, SensorEntity):
     """Sensor for the service version on the remote PC."""
 
     _attr_has_entity_name = True
@@ -91,18 +76,8 @@ class PcRemoteVersionSensor(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the service version sensor."""
-        super().__init__(coordinator)
-        self._entry = entry
+        super().__init__(coordinator, entry)
         self._attr_unique_id = f"{entry.entry_id}_service_version"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/pc_remote/switch.py
+++ b/custom_components/pc_remote/switch.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from wakeonlan import send_magic_packet
-
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api import CannotConnectError, PcRemoteClient
-from .const import CONF_MAC_ADDRESS, DOMAIN
+from .const import DOMAIN
 from .coordinator import PcRemoteCoordinator
 from .entity_base import PcRemoteEntityBase
 
@@ -67,7 +65,6 @@ class PcRemotePowerSwitch(PcRemoteEntityBase, SwitchEntity):
         """Initialize the power switch."""
         super().__init__(coordinator, entry)
         self._client = client
-        self._mac: str = entry.data.get(CONF_MAC_ADDRESS, "")
         self._attr_unique_id = f"{entry.entry_id}_power"
 
     @property
@@ -81,17 +78,8 @@ class PcRemotePowerSwitch(PcRemoteEntityBase, SwitchEntity):
         return self.coordinator.data.online
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Wake the PC via Wake-on-LAN."""
-        if not self._mac:
-            _LOGGER.error("MAC address not configured, cannot send WoL packet")
-            return
-        try:
-            await self.hass.async_add_executor_job(send_magic_packet, self._mac)
-        except (ValueError, OSError) as err:
-            _LOGGER.error("Failed to send WoL packet: %s", err)
-            return
-        self.coordinator.set_power_state(True)
-        self.async_write_ha_state()
+        """Wake the PC via sustained Wake-on-LAN."""
+        await self.coordinator.async_wake_and_wait()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Put the PC to sleep."""

--- a/custom_components/pc_remote/switch.py
+++ b/custom_components/pc_remote/switch.py
@@ -10,13 +10,12 @@ from wakeonlan import send_magic_packet
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import CannotConnectError, PcRemoteClient
-from .const import CONF_MAC_ADDRESS, DOMAIN, build_device_info
+from .const import CONF_MAC_ADDRESS, DOMAIN
 from .coordinator import PcRemoteCoordinator
+from .entity_base import PcRemoteEntityBase
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,9 +50,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PcRemotePowerSwitch(
-    CoordinatorEntity[PcRemoteCoordinator], SwitchEntity
-):
+class PcRemotePowerSwitch(PcRemoteEntityBase, SwitchEntity):
     """Switch that wakes or sleeps the PC."""
 
     _attr_has_entity_name = True
@@ -68,20 +65,10 @@ class PcRemotePowerSwitch(
         entry: ConfigEntry,
     ) -> None:
         """Initialize the power switch."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._mac: str = entry.data.get(CONF_MAC_ADDRESS, "")
         self._attr_unique_id = f"{entry.entry_id}_power"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
 
     @property
     def available(self) -> bool:
@@ -116,9 +103,7 @@ class PcRemotePowerSwitch(
         self.async_write_ha_state()
 
 
-class PcRemoteAppSwitch(
-    CoordinatorEntity[PcRemoteCoordinator], SwitchEntity
-):
+class PcRemoteAppSwitch(PcRemoteEntityBase, SwitchEntity):
     """Switch that launches or kills an app on the PC."""
 
     _attr_has_entity_name = True
@@ -133,26 +118,11 @@ class PcRemoteAppSwitch(
         display_name: str,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, entry)
         self._client = client
-        self._entry = entry
         self._app_key = app_key
         self._attr_name = display_name
         self._attr_unique_id = f"{entry.entry_id}_app_{app_key}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info from latest coordinator data."""
-        return build_device_info(
-            self._entry,
-            machine_name=self.coordinator.data.machine_name,
-            sw_version=self.coordinator.data.service_version,
-        )
-
-    @property
-    def available(self) -> bool:
-        """Available only when the PC is online."""
-        return super().available and self.coordinator.data.online
 
     @property
     def is_on(self) -> bool | None:
@@ -163,7 +133,9 @@ class PcRemoteAppSwitch(
         return None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Launch the app."""
+        """Launch the app, waking the PC first if needed."""
+        if not await self.coordinator.async_ensure_online():
+            return
         await self._client.launch_app(self._app_key)
         await self.coordinator.async_request_refresh()
 
@@ -171,4 +143,3 @@ class PcRemoteAppSwitch(
         """Kill the app."""
         await self._client.kill_app(self._app_key)
         await self.coordinator.async_request_refresh()
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,8 @@ def make_mock_coordinator(data: PcRemoteData | None = None) -> MagicMock:
     coordinator.hass.async_create_task = MagicMock()
     coordinator.async_request_refresh = AsyncMock()
     coordinator.persist_selection = AsyncMock()
+    coordinator.async_ensure_online = AsyncMock(return_value=True)
+    coordinator.async_wake_and_wait = AsyncMock(return_value=True)
     coordinator.available = True
     return coordinator
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,16 +14,17 @@ from custom_components.pc_remote.coordinator import (
     PcRemoteCoordinator,
     PcRemoteData,
 )
-from tests.conftest import make_mock_client
+from tests.conftest import make_mock_client, make_mock_entry
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_coordinator(hass, client=None) -> PcRemoteCoordinator:
+def _make_coordinator(hass, client=None, entry=None) -> PcRemoteCoordinator:
     client = client or make_mock_client()
-    return PcRemoteCoordinator(hass, client, entry_id="entry1")
+    entry = entry or make_mock_entry()
+    return PcRemoteCoordinator(hass, client, entry)
 
 
 def _full_system_state() -> dict:
@@ -422,3 +423,108 @@ class TestRestoreSelections:
         data = await coord._async_update_data()
 
         assert data.current_mode == "Gaming"
+
+
+# ---------------------------------------------------------------------------
+# Wake-on-LAN
+# ---------------------------------------------------------------------------
+
+class TestWakeOnLan:
+    @pytest.mark.asyncio
+    async def test_ensure_online_returns_true_when_already_online(self, hass):
+        client = make_mock_client()
+        client.get_health.return_value = {"machineName": "PC", "version": "1.0"}
+        client.get_system_state.return_value = _full_system_state()
+
+        coord = _make_coordinator(hass, client)
+        await coord._async_update_data()  # set online=True
+
+        result = await coord.async_ensure_online()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_ensure_online_wakes_when_offline(self, hass):
+        client = make_mock_client()
+        client.get_health.side_effect = CannotConnectError("refused")
+
+        coord = _make_coordinator(hass, client)
+        await coord._async_update_data()  # set online=False
+
+        # Now make health succeed on wake polling
+        client.get_health.side_effect = None
+        client.get_health.return_value = {"machineName": "PC", "version": "1.0"}
+
+        result = await coord.async_ensure_online()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_wake_and_wait_no_mac_returns_false(self, hass):
+        entry = make_mock_entry()
+        entry.data = {"host": "h", "port": 5000, "api_key": "k"}
+        coord = _make_coordinator(hass, entry=entry)
+
+        result = await coord.async_wake_and_wait()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_wake_and_wait_timeout_returns_false(self, hass):
+        client = make_mock_client()
+        client.get_health.side_effect = CannotConnectError("still down")
+
+        coord = _make_coordinator(hass, client)
+
+        result = await coord.async_wake_and_wait()
+        assert result is False
+        assert not coord._fast_polling  # restored after timeout
+
+    @pytest.mark.asyncio
+    async def test_wake_and_wait_sets_fast_poll(self, hass):
+        client = make_mock_client()
+        # Succeed on first health poll
+        coord = _make_coordinator(hass, client)
+
+        await coord.async_wake_and_wait()
+
+        assert coord._fast_polling is True
+        assert coord.update_interval == timedelta(seconds=1)
+
+    @pytest.mark.asyncio
+    async def test_fast_poll_restored_on_online(self, hass):
+        client = make_mock_client()
+        client.get_health.return_value = {"machineName": "PC", "version": "1.0"}
+        client.get_system_state.return_value = _full_system_state()
+
+        coord = _make_coordinator(hass, client)
+        coord._start_fast_poll()
+        assert coord._fast_polling is True
+
+        await coord._async_update_data()
+        assert coord._fast_polling is False
+        assert coord.update_interval == timedelta(seconds=30)
+
+    @pytest.mark.asyncio
+    async def test_fast_poll_expires_when_pc_stays_offline(self, hass):
+        client = make_mock_client()
+        client.get_health.side_effect = CannotConnectError("still down")
+
+        coord = _make_coordinator(hass, client)
+        coord._start_fast_poll()
+        # Simulate time past FAST_POLL_DURATION
+        coord._fast_poll_start = time.monotonic() - 200
+
+        await coord._async_update_data()
+        assert coord._fast_polling is False
+        assert coord.update_interval == timedelta(seconds=30)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_wake_shares_task(self, hass):
+        client = make_mock_client()
+        coord = _make_coordinator(hass, client)
+
+        # Both calls should return the same result
+        task1 = asyncio.ensure_future(coord.async_wake_and_wait())
+        task2 = asyncio.ensure_future(coord.async_wake_and_wait())
+        r1, r2 = await asyncio.gather(task1, task2)
+
+        assert r1 is True
+        assert r2 is True

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -66,16 +66,6 @@ class TestAudioOutputSelect:
         entity, *_ = _make_entity(PcRemoteAudioOutputSelect, data)
         assert entity.current_option is None
 
-    def test_available_when_online(self):
-        data = make_coordinator_data(online=True)
-        entity, *_ = _make_entity(PcRemoteAudioOutputSelect, data)
-        assert entity.available is True
-
-    def test_unavailable_when_offline(self):
-        data = make_coordinator_data(online=False)
-        entity, *_ = _make_entity(PcRemoteAudioOutputSelect, data)
-        assert entity.available is False
-
     @pytest.mark.asyncio
     async def test_select_option_calls_api_and_updates_data(self):
         data = make_coordinator_data(
@@ -89,13 +79,23 @@ class TestAudioOutputSelect:
         assert coordinator.data.current_audio_device == "Headphones"
 
     @pytest.mark.asyncio
-    async def test_select_option_propagates_api_error(self):
-        data = make_coordinator_data()
+    async def test_select_option_auto_wakes(self):
+        data = make_coordinator_data(online=False)
         entity, coordinator, client = _make_entity(PcRemoteAudioOutputSelect, data)
-        client.set_audio_device.side_effect = CannotConnectError("refused")
 
-        with pytest.raises(CannotConnectError):
-            await entity.async_select_option("Headphones")
+        await entity.async_select_option("Headphones")
+
+        coordinator.async_ensure_online.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_select_option_aborts_when_wake_fails(self):
+        data = make_coordinator_data(online=False)
+        entity, coordinator, client = _make_entity(PcRemoteAudioOutputSelect, data)
+        coordinator.async_ensure_online.return_value = False
+
+        await entity.async_select_option("Headphones")
+
+        client.set_audio_device.assert_not_awaited()
 
     def test_unique_id_includes_entry_id(self):
         entry = make_mock_entry(entry_id="abc")
@@ -103,7 +103,6 @@ class TestAudioOutputSelect:
         assert entity._attr_unique_id == "abc_audio_output"
 
 
-# ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 # PcRemoteMonitorSoloSelect
 # ---------------------------------------------------------------------------
@@ -172,10 +171,27 @@ class TestMonitorSoloSelect:
         client.solo_monitor.assert_not_awaited()
         coordinator.async_request_refresh.assert_not_awaited()
 
-    def test_unavailable_when_offline(self):
+    @pytest.mark.asyncio
+    async def test_solo_auto_wakes(self):
         data = make_coordinator_data(online=False)
-        entity, *_ = _make_entity(PcRemoteMonitorSoloSelect, data)
-        assert entity.available is False
+        entity, coordinator, client = _make_entity(PcRemoteMonitorSoloSelect, data)
+
+        await entity.async_select_option("Dell")
+
+        coordinator.async_ensure_online.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_solo_aborts_when_wake_fails(self):
+        data = make_coordinator_data(
+            online=False,
+            monitors=[{"monitorId": "m1", "monitorName": "Dell", "isPrimary": True}],
+        )
+        entity, coordinator, client = _make_entity(PcRemoteMonitorSoloSelect, data)
+        coordinator.async_ensure_online.return_value = False
+
+        await entity.async_select_option("Dell")
+
+        client.solo_monitor.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -197,11 +213,6 @@ class TestModeSelect:
         data = make_coordinator_data(modes=["Gaming"])
         entity, *_ = _make_entity(PcRemoteModeSelect, data)
         assert entity.current_option is None
-
-    def test_unavailable_when_offline(self):
-        data = make_coordinator_data(online=False)
-        entity, *_ = _make_entity(PcRemoteModeSelect, data)
-        assert entity.available is False
 
     @pytest.mark.asyncio
     async def test_select_option_calls_api_and_persists_mode(self):
@@ -226,13 +237,23 @@ class TestModeSelect:
         assert coordinator.data.current_mode == "Gaming"
 
     @pytest.mark.asyncio
-    async def test_select_option_api_failure_propagates(self):
-        data = make_coordinator_data(modes=["Gaming"])
+    async def test_select_option_auto_wakes(self):
+        data = make_coordinator_data(online=False, modes=["Gaming"])
         entity, coordinator, client = _make_entity(PcRemoteModeSelect, data)
-        client.set_mode.side_effect = CannotConnectError("refused")
 
-        with pytest.raises(CannotConnectError):
-            await entity.async_select_option("Gaming")
+        await entity.async_select_option("Gaming")
+
+        coordinator.async_ensure_online.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_select_option_aborts_when_wake_fails(self):
+        data = make_coordinator_data(online=False, modes=["Gaming"])
+        entity, coordinator, client = _make_entity(PcRemoteModeSelect, data)
+        coordinator.async_ensure_online.return_value = False
+
+        await entity.async_select_option("Gaming")
+
+        client.set_mode.assert_not_awaited()
 
     def test_unique_id_includes_entry_id(self):
         entry = make_mock_entry(entry_id="xyz")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -176,16 +176,6 @@ class TestAppSwitchState:
         switch, *_ = _make_app_switch("unknown_app", "Unknown", data)
         assert switch.is_on is None
 
-    def test_unavailable_when_offline(self):
-        data = make_coordinator_data(online=False)
-        switch, *_ = _make_app_switch(data=data)
-        assert switch.available is False
-
-    def test_available_when_online(self):
-        data = make_coordinator_data(online=True)
-        switch, *_ = _make_app_switch(data=data)
-        assert switch.available is True
-
     def test_unique_id_includes_entry_id_and_key(self):
         entry = make_mock_entry(entry_id="myentry")
         switch, *_ = _make_app_switch("steam", "Steam", entry=entry)
@@ -212,6 +202,26 @@ class TestAppSwitchCommands:
         coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_turn_on_auto_wakes_when_offline(self):
+        data = make_coordinator_data(online=False, apps=[])
+        switch, coordinator, client = _make_app_switch("chrome", "Chrome", data)
+
+        await switch.async_turn_on()
+
+        coordinator.async_ensure_online.assert_awaited_once()
+        client.launch_app.assert_awaited_once_with("chrome")
+
+    @pytest.mark.asyncio
+    async def test_turn_on_aborts_when_wake_fails(self):
+        data = make_coordinator_data(online=False, apps=[])
+        switch, coordinator, client = _make_app_switch("chrome", "Chrome", data)
+        coordinator.async_ensure_online.return_value = False
+
+        await switch.async_turn_on()
+
+        client.launch_app.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_turn_off_kills_app(self):
         data = make_coordinator_data(online=True, apps=[])
         switch, coordinator, client = _make_app_switch("chrome", "Chrome", data)
@@ -220,21 +230,3 @@ class TestAppSwitchCommands:
 
         client.kill_app.assert_awaited_once_with("chrome")
         coordinator.async_request_refresh.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_turn_on_api_failure_propagates(self):
-        data = make_coordinator_data(online=True)
-        switch, coordinator, client = _make_app_switch(data=data)
-        client.launch_app.side_effect = CannotConnectError("no conn")
-
-        with pytest.raises(CannotConnectError):
-            await switch.async_turn_on()
-
-    @pytest.mark.asyncio
-    async def test_turn_off_api_failure_propagates(self):
-        data = make_coordinator_data(online=True)
-        switch, coordinator, client = _make_app_switch(data=data)
-        client.kill_app.side_effect = CannotConnectError("no conn")
-
-        with pytest.raises(CannotConnectError):
-            await switch.async_turn_off()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -77,51 +77,22 @@ class TestPowerSwitchState:
 
 class TestPowerSwitchTurnOn:
     @pytest.mark.asyncio
-    async def test_turn_on_sends_wol_and_sets_power_state(self):
-        entry = make_mock_entry(mac_address="AA:BB:CC:DD:EE:FF")
+    async def test_turn_on_delegates_to_async_wake_and_wait(self):
         data = make_coordinator_data(online=False)
-        switch, coordinator, client = _make_power_switch(data=data, entry=entry)
+        switch, coordinator, client = _make_power_switch(data=data)
 
         await switch.async_turn_on()
 
-        coordinator.hass.async_add_executor_job.assert_awaited_once()
-        coordinator.set_power_state.assert_called_once_with(True)
+        coordinator.async_wake_and_wait.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_turn_on_no_mac_does_nothing(self):
-        entry = make_mock_entry(mac_address="")
-        # Override data dict to clear mac
-        entry.data = {"host": "host", "port": 5000, "api_key": "k", "mac_address": ""}
+    async def test_turn_on_does_not_call_send_magic_packet_directly(self):
         data = make_coordinator_data(online=False)
-        switch, coordinator, client = _make_power_switch(data=data, entry=entry)
+        switch, coordinator, client = _make_power_switch(data=data)
 
         await switch.async_turn_on()
 
         coordinator.hass.async_add_executor_job.assert_not_awaited()
-        coordinator.set_power_state.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_turn_on_wol_os_error_does_not_propagate(self):
-        entry = make_mock_entry(mac_address="AA:BB:CC:DD:EE:FF")
-        data = make_coordinator_data(online=False)
-        switch, coordinator, client = _make_power_switch(data=data, entry=entry)
-        coordinator.hass.async_add_executor_job.side_effect = OSError("network error")
-
-        # Should not raise
-        await switch.async_turn_on()
-
-        coordinator.set_power_state.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_turn_on_wol_value_error_does_not_propagate(self):
-        entry = make_mock_entry(mac_address="INVALID")
-        data = make_coordinator_data(online=False)
-        switch, coordinator, client = _make_power_switch(data=data, entry=entry)
-        coordinator.hass.async_add_executor_job.side_effect = ValueError("bad mac")
-
-        await switch.async_turn_on()
-
-        coordinator.set_power_state.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Auto-wake before actions** — all entities now wake the PC via sustained WoL before performing actions (#39)
- **Switch entity sustained WoL** — power switch uses `coordinator.async_wake_and_wait()` instead of single packet (#40)
- **Coordinator refresh on browse** — triggers data refresh when browsing games

Closes #39, Closes #40